### PR TITLE
docs: add roadmap source briefs

### DIFF
--- a/.github/issue-backlog/_conventions.md
+++ b/.github/issue-backlog/_conventions.md
@@ -1,0 +1,38 @@
+# Issue Backlog Conventions
+
+These conventions keep Muninn roadmap issues implementable by humans and coding agents.
+
+## Labels
+
+- `P1`: blocks alpha or public credibility.
+- `P2`: important after P1, or high-value polish.
+- `P3`: opportunistic, cleanup, or post-GA.
+- `phase:now`: alpha-exit and 2.0.0 GA scope.
+- `phase:next`: post-GA or stretch scope.
+- `ai-ready`: issue has enough file paths, expected behavior, and acceptance criteria for an agent to implement.
+- `needs-human`: requires accounts, credentials, public voice, legal judgment, or subjective maintainer review.
+
+## Issue Body Shape
+
+Use this order where practical:
+
+1. Context.
+2. Current behavior.
+3. Desired behavior.
+4. Scope.
+5. Acceptance criteria.
+6. Out of scope.
+
+## Agent Rules
+
+- Verify file paths before editing.
+- Keep round-trip Markdown behavior explicit.
+- Do not add telemetry.
+- Do not weaken workspace-trust behavior.
+- Do not introduce extra webviews unless the architecture document is updated and the issue explicitly calls for it.
+- Use localized strings for user-facing text.
+- Add tests proportional to the behavior changed.
+
+## Dependency References
+
+Always reference real GitHub issue numbers. Do not leave planning placeholders such as `#001` or `#014` in public issues.

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -1,0 +1,62 @@
+# AI Agent Guide
+
+Repository instructions for AI coding agents working on Muninn for VS Code.
+
+## Product Reality
+
+Muninn v2 is a VS Code custom Markdown editor. It is not the old preview-mode extension.
+
+- Custom editor id: `muninn.markdownEditor`.
+- Host entry: `src/extension.ts`.
+- Custom editor provider: `src/custom-editor/muninn-custom-editor-provider.ts`.
+- Message protocol and guards: `src/custom-editor/protocol.ts`.
+- Webview editor: `src/webview/editor/`.
+- Table node view: `src/webview/editor/nodes/table-node-view.ts`.
+- Mermaid rendering: `src/webview/editor/preview.ts` and `src/webview/editor/renderers/mermaid-renderer.ts`.
+
+```mermaid
+flowchart LR
+  A["VS Code host"] --> B["CustomTextEditorProvider"]
+  B --> C["Revisioned document sync"]
+  C --> D["Webview ProseMirror editor"]
+  D --> E["Tables"]
+  D --> F["Mermaid"]
+```
+
+## Prime Directive
+
+Do not introduce unrelated Markdown serialization churn.
+
+When changing parsing, serialization, tables, source toggling, or document sync, add or update round-trip coverage. If exact round-trip behavior is impossible, document the deviation.
+
+## Required Checks
+
+Run the smallest relevant checks while developing, then the broader set before PR handoff:
+
+```bash
+npm run lint
+npm run format:check
+npm run typecheck
+npm run coverage
+npm run test:e2e
+```
+
+If a check is not runnable in your environment, say exactly which one and why.
+
+## Forbidden Without Explicit Issue Scope
+
+- Telemetry.
+- Network calls at runtime.
+- `eval` or script execution from document content.
+- Weakening CSP, nonce handling, or workspace-trust gates.
+- Replacing the custom editor with VS Code's built-in Markdown preview flow.
+- Adding a second Markdown editor architecture.
+- Silent Markdown normalization unrelated to the user's edit.
+
+## User-Facing Text
+
+Use the existing localization pattern. Do not hardcode new user-visible strings in the webview or extension host if the surrounding code uses localized bundles.
+
+## Public Claims
+
+Do not add README or Marketplace claims that are not supported by shipped code or committed docs.

--- a/docs/MARKET_POSITION_2026-06.md
+++ b/docs/MARKET_POSITION_2026-06.md
@@ -1,0 +1,81 @@
+# Muninn Market Position - June 2026
+
+This document is the source brief for the June 2026 visibility roadmap.
+
+## Goal
+
+Increase GitHub visibility, stars, and first installs for Muninn for VS Code by making the project easy to understand, safe to trust, and simple to try.
+
+## Positioning
+
+Muninn is a reading-first Markdown editor for VS Code. The core promise is:
+
+> A WYSIWYG Markdown editor that does not churn your source.
+
+That promise matters because Markdown users are usually not looking for a new note-taking silo. They want to stay in their repo, keep plain `.md` files, and avoid preview/edit ping-pong.
+
+```mermaid
+flowchart LR
+  A["Developer opens README/spec"] --> B["Reads in a calm single pane"]
+  B --> C["Edits rich content inline"]
+  C --> D["Toggles raw Markdown when needed"]
+  D --> E["Saves without unrelated byte churn"]
+```
+
+## Competitive Landscape
+
+### Direct competitors
+
+- `zaaack.markdown-editor`
+  - Mature Marketplace presence.
+  - Good search discoverability for "WYSIWYG markdown".
+  - Risk to beat: users assume the category already exists and do not search deeper.
+- `concretio.markdown-for-humans`
+  - Strong current positioning around visual tables, images, Mermaid, and no paywall.
+  - Publishes on both VS Code Marketplace and Open VSX, which matters for Cursor, Windsurf, and VSCodium users.
+- Markdown Preview Enhanced / Markdown All in One / native preview
+  - Strong feature depth, but preview-led rather than editor-led.
+
+### Muninn wedge
+
+Muninn should not fight on "most features" first. The initial wedge is trust:
+
+- Round-trip correctness is measured and published.
+- No telemetry.
+- Workspace-trust behavior is explicit.
+- Mermaid and webview behavior are documented.
+- Source escape hatch is always available.
+
+## Launch Strategy
+
+1. Publish a usable alpha.
+2. Publish the proof: round-trip report, security posture, and accessibility work.
+3. Polish the listing: README, hero GIF, Marketplace metadata, Open VSX.
+4. Engage where Markdown WYSIWYG is already being discussed.
+5. Convert learning into blog posts and outreach.
+
+## Roadmap Mapping
+
+- Publish/install funnel: issues `#243`, `#244`, `#270`, `#277`.
+- Trust proof: issues `#245`, `#260`, `#267`.
+- First-run UX: issues `#246` through `#259`, `#261` through `#263`.
+- Marketing/visibility: issues `#269`, `#272`, `#278`.
+- Post-GA feature expansion: issues `#273` through `#276`.
+
+## Messaging
+
+Use plain claims that can be backed by repo evidence:
+
+- "Single-pane Markdown editing inside VS Code."
+- "Visual tables and Mermaid without leaving your repo."
+- "No telemetry."
+- "Round-trip behavior tested against a public corpus."
+- "Built for people who read Markdown before they edit it."
+
+Avoid vague claims like "revolutionary", "AI-native", or "the future of writing". They smell like a SaaS homepage after three espressos.
+
+## Open Questions
+
+- License strategy is unresolved in `main`: current repo files still say MIT. Do not implement AGPL compliance tickets until the license decision is explicit.
+- The alpha should prioritize installability and proof over feature sprawl.
+- Any public outreach should happen under the maintainer's real voice, not automated mass pitching.

--- a/docs/PROJECT_CONSTITUTION.md
+++ b/docs/PROJECT_CONSTITUTION.md
@@ -1,0 +1,30 @@
+# Project Constitution
+
+## 1. Custom Editor Architecture
+
+Muninn v2 is a custom Markdown editor based on VS Code's `CustomTextEditorProvider`. Custom webview usage is allowed only for the sanctioned Muninn editor architecture documented in `docs/ARCHITECTURE.md`.
+
+## 2. Markdown Fidelity
+
+Markdown source fidelity is a product contract. Changes to parser, serializer, table transforms, source toggling, or document sync must preserve unrelated bytes or document known deviations.
+
+## 3. Local-First Behavior
+
+Muninn edits local Markdown documents in the user's workspace. Runtime telemetry, cloud sync, and remote document processing are out of scope unless explicitly approved in a future architecture decision.
+
+## 4. Trust and Security
+
+The extension must keep a strict webview posture:
+
+- CSP remains nonce-based.
+- Document content must not execute scripts.
+- Mermaid behavior must respect workspace trust.
+- Host/webview messages must be validated.
+
+## 5. Accessibility
+
+Keyboard and screen-reader flows are part of the editor contract, not optional polish. Public alpha work must prioritize toolbar navigation, table semantics, editor naming, and error announcements.
+
+## 6. Documentation Honesty
+
+README, Marketplace copy, roadmap docs, and agent instructions must describe the current custom-editor product, not the historical preview-mode product.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,17 +6,22 @@ Welcome to the **Muninn for VS Code** extension engineering documentation. This 
 
 ## Documentation Index
 
-| Document                                                                 | Description                                                  | Audience                 |
-| ------------------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------ |
-| [GETTING_STARTED.md](GETTING_STARTED.md)                                 | New contributor onboarding, first run, and common commands   | Newcomers                |
-| [ARCHITECTURE.md](ARCHITECTURE.md)                                       | System design, module overview, and data flow diagrams       | Developers, Contributors |
-| [DEVELOPMENT.md](DEVELOPMENT.md)                                         | Setup guide, development workflow, and debugging tips        | New Contributors         |
-| [TESTING.md](TESTING.md)                                                 | Test structure, running tests, and writing new tests         | Developers, QA           |
-| [RELEASE.md](RELEASE.md)                                                 | Release process checklist and versioning guidelines          | Maintainers              |
-| [TROUBLESHOOTING.md](TROUBLESHOOTING.md)                                 | Common issues and solutions for developers                   | All                      |
-| [ROADMAP.md](ROADMAP.md)                                                 | Feature roadmap and milestone planning                       | All                      |
-| [BRAND_NAMING_CONTRACT.md](BRAND_NAMING_CONTRACT.md)                     | Canonical naming, IDs, and logo rules for the Muninn suite   | Maintainers, Product     |
-| [MIGRATION_FROM_MARKDOWN_PREVIEW.md](MIGRATION_FROM_MARKDOWN_PREVIEW.md) | Hard-break migration from legacy extension ID and namespaces | Maintainers, Users       |
+| Document                                                                       | Description                                                  | Audience                  |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------- |
+| [GETTING_STARTED.md](GETTING_STARTED.md)                                       | New contributor onboarding, first run, and common commands   | Newcomers                 |
+| [ARCHITECTURE.md](ARCHITECTURE.md)                                             | System design, module overview, and data flow diagrams       | Developers, Contributors  |
+| [DEVELOPMENT.md](DEVELOPMENT.md)                                               | Setup guide, development workflow, and debugging tips        | New Contributors          |
+| [TESTING.md](TESTING.md)                                                       | Test structure, running tests, and writing new tests         | Developers, QA            |
+| [RELEASE.md](RELEASE.md)                                                       | Release process checklist and versioning guidelines          | Maintainers               |
+| [TROUBLESHOOTING.md](TROUBLESHOOTING.md)                                       | Common issues and solutions for developers                   | All                       |
+| [ROADMAP.md](ROADMAP.md)                                                       | Feature roadmap and milestone planning                       | All                       |
+| [MARKET_POSITION_2026-06.md](MARKET_POSITION_2026-06.md)                       | June 2026 market brief and visibility strategy               | Maintainers, Product      |
+| [AI_AGENT_GUIDE.md](AI_AGENT_GUIDE.md)                                         | Repo instructions for AI coding agents                       | AI Agents, Maintainers    |
+| [PROJECT_CONSTITUTION.md](PROJECT_CONSTITUTION.md)                             | Current product and engineering principles                   | Maintainers, Contributors |
+| [BRAND_NAMING_CONTRACT.md](BRAND_NAMING_CONTRACT.md)                           | Canonical naming, IDs, and logo rules for the Muninn suite   | Maintainers, Product      |
+| [MIGRATION_FROM_MARKDOWN_PREVIEW.md](MIGRATION_FROM_MARKDOWN_PREVIEW.md)       | Hard-break migration from legacy extension ID and namespaces | Maintainers, Users        |
+| [design/ACCESSIBILITY_AUDIT_2026-06.md](design/ACCESSIBILITY_AUDIT_2026-06.md) | June 2026 accessibility audit behind roadmap work            | Developers, QA            |
+| [design/DESIGN_CRITIQUE_2026-06.md](design/DESIGN_CRITIQUE_2026-06.md)         | June 2026 UX critique behind roadmap work                    | Developers, Product       |
 
 ## Quick Links
 
@@ -47,7 +52,7 @@ muninn-vscode/
 ├── docs/                   # This documentation folder
 ├── assets/                 # Images and icons
 ├── specs/                  # Feature specifications (SpecKit)
-└── .specify/               # AI tooling configuration
+└── .specify/               # Local AI tooling configuration (ignored)
 ```
 
 ## Key Concepts

--- a/docs/design/ACCESSIBILITY_AUDIT_2026-06.md
+++ b/docs/design/ACCESSIBILITY_AUDIT_2026-06.md
@@ -1,0 +1,77 @@
+# Accessibility Audit - June 2026
+
+This audit records the accessibility issues behind the June 2026 roadmap. It is scoped to WCAG 2.1 AA expectations for the Muninn custom editor webview.
+
+## Summary
+
+The editor is usable for pointer-driven workflows, but several keyboard and screen-reader paths need hardening before a credible public alpha.
+
+```mermaid
+flowchart TD
+  A["Keyboard access"] --> B["Toolbar navigation"]
+  A --> C["Table cell editing"]
+  D["Screen readers"] --> E["Editor name"]
+  D --> F["Table semantics"]
+  D --> G["Mermaid alternatives"]
+  H["Status feedback"] --> I["Assertive errors"]
+  H --> J["Non-color cues"]
+```
+
+## Findings
+
+### 1. Toolbar uses `role="toolbar"` without the ARIA toolbar keyboard model
+
+- Severity: P1
+- Roadmap issue: `#246`
+- Current risk: every toolbar button is a tab stop, so keyboard users must tab through the full toolbar before reaching the document.
+- Expected behavior: one toolbar tab stop, arrow-key navigation inside the toolbar, Home/End support, and focus restricted to visible controls.
+
+### 2. Mermaid output has weak screen-reader semantics
+
+- Severity: P1
+- Roadmap issue: `#247`
+- Current risk: rendered diagrams can be visually useful while being mostly invisible or unnamed to assistive technology.
+- Expected behavior: rendered diagram containers need accessible names, text alternatives where practical, and announced show/hide state changes.
+
+### 3. Table node view lacks complete table semantics
+
+- Severity: P1
+- Roadmap issue: `#248`
+- Current risk: editable tables are hard to distinguish when multiple tables exist and header relationships are not explicit enough.
+- Expected behavior: header cells use `scope="col"` and each editable table has a useful accessible name.
+
+### 4. Table keyboard editing drops focus
+
+- Severity: P1
+- Roadmap issue: `#249`
+- Current risk: pressing Enter commits by blurring the input, leaving keyboard users without a stable place in the table.
+- Expected behavior: spreadsheet-like flow with Enter committing and moving down, Escape reverting, arrow-key cell navigation, and focus preservation after DOM rebuilds.
+
+### 5. ProseMirror editor surface has no accessible name
+
+- Severity: P2
+- Roadmap issue: `#251`
+- Current risk: screen-reader users land on an unlabeled contenteditable region.
+- Expected behavior: the actual contenteditable element has a localized label, `role="textbox"`, and `aria-multiline="true"`.
+
+### 6. Errors and statuses share one polite channel
+
+- Severity: P2
+- Roadmap issue: `#252`
+- Current risk: failures can be announced too softly or look like normal statuses. Some table feedback relies on color only.
+- Expected behavior: errors use an assertive alert channel with explicit "Error" language and non-color cues.
+
+### 7. Manual screen-reader verification is still required
+
+- Severity: P1
+- Roadmap issue: `#260`
+- Current risk: automated checks cannot prove the editor feels coherent in VoiceOver and NVDA.
+- Expected behavior: run a manual pass after issues `#246` through `#252` land.
+
+## Acceptance Bar
+
+Muninn should not claim accessibility maturity until the P1 items are fixed and manually verified with at least:
+
+- VoiceOver on macOS.
+- NVDA on Windows.
+- Keyboard-only smoke flow: open file, use toolbar, edit a table, toggle source, inspect Mermaid output.

--- a/docs/design/DESIGN_CRITIQUE_2026-06.md
+++ b/docs/design/DESIGN_CRITIQUE_2026-06.md
@@ -1,0 +1,72 @@
+# Design Critique - June 2026
+
+This critique supports the June 2026 roadmap. It focuses on whether Muninn feels like a reading-first Markdown editor rather than a busy web app inside VS Code.
+
+## Product Principle
+
+Chrome should earn its pixels. The document is the product.
+
+```mermaid
+flowchart LR
+  A["Current editor"] --> B["Reduce persistent chrome"]
+  A --> C["Improve reading measure"]
+  A --> D["Make insertion behavior predictable"]
+  A --> E["Keep advanced tools discoverable but quiet"]
+```
+
+## Findings
+
+### 1. Text measure is too wide on large monitors
+
+- Severity: P1
+- Roadmap issue: `#253`
+- Problem: paragraphs can stretch across the full editor width, which weakens the reading-first promise.
+- Recommendation: default to a centered content column around 70ch, with a setting for users who prefer full width.
+
+### 2. Basic toolbar hides common Markdown actions
+
+- Severity: P2
+- Roadmap issue: `#254`
+- Problem: list buttons are hidden behind "More" even though bullet and numbered lists are core Markdown operations.
+- Recommendation: keep Bold, Italic, Link, H1, H2, Bullet list, Numbered list, Table, and Source in the basic tier.
+
+### 3. Mermaid has two preview models
+
+- Severity: P2
+- Roadmap issue: `#255`
+- Problem: a global preview panel and per-block preview can show duplicated or mismatched diagrams.
+- Recommendation: use per-block previews only. They are spatially honest and easier to reason about.
+
+### 4. Block insertion can destroy selected text
+
+- Severity: P2
+- Roadmap issue: `#256`
+- Problem: inserting a table, code block, or Mermaid block with text selected replaces content unexpectedly.
+- Recommendation: insert after the current top-level block except when replacing an empty paragraph.
+
+### 5. Cancelled link input leaves a stale status
+
+- Severity: P3
+- Roadmap issue: `#257`
+- Problem: dismissing host input can leave the status line stuck on "Awaiting link input".
+- Recommendation: send an explicit cancellation message and restore focus/status.
+
+### 6. Brand header competes with document content
+
+- Severity: P2
+- Roadmap issue: `#258`
+- Problem: the persistent header repeats identity that the tab and listing already provide.
+- Recommendation: fold identity into the status line and reclaim vertical space.
+
+### 7. Small polish items should be batched
+
+- Severity: P3
+- Roadmap issue: `#259`
+- Problem: dead CSS, mixed active-state mechanics, fixed font-size, and missing hidden heading are too small for separate roadmap tickets.
+- Recommendation: keep them bundled.
+
+## Non-Goals
+
+- Do not turn the editor into a landing page.
+- Do not add decorative panels around the document.
+- Do not chase Notion-style block editor parity before installability and trust proof.

--- a/specs/round-trip-correctness/spec.md
+++ b/specs/round-trip-correctness/spec.md
@@ -1,0 +1,67 @@
+# Round-Trip Correctness Specification
+
+## Purpose
+
+Muninn's headline promise is that rich editing should not rewrite unrelated Markdown. This spec defines the testable contract for Markdown to ProseMirror to Markdown round trips.
+
+## Pipeline Under Test
+
+```mermaid
+flowchart LR
+  A["Markdown bytes"] --> B["wrapTablesForEditor"]
+  B --> C["markdownParser.parse"]
+  C --> D["markdownSerializer.serialize"]
+  D --> E["unwrapTablesForHost"]
+  E --> F["Markdown bytes"]
+```
+
+The expected result is byte-identical output for supported constructs. When byte identity is not currently possible, the deviation must be documented instead of hidden.
+
+## Required Corpus
+
+Create one or more fixture files for each category:
+
+- ATX headings 1 through 6.
+- Setext headings.
+- Paragraphs with soft and hard breaks.
+- Emphasis, strong, and code-span edge cases.
+- Inline links, reference links, and autolinks.
+- Images.
+- Nested blockquotes.
+- Fenced code blocks using backticks and tildes.
+- Indented code blocks.
+- Bullet lists using `-`, `*`, and `+`.
+- Ordered lists with custom start numbers and both delimiter styles.
+- GFM tables, including alignment colons, escaped pipes, and ragged rows.
+- Task lists.
+- Thematic breaks using `---`, `***`, and `___`.
+- HTML blocks as pass-through content according to the current parser policy.
+- YAML front matter.
+- Trailing whitespace and no-final-newline cases.
+- CRLF input.
+- Unicode text.
+- Mermaid fenced blocks.
+
+## Known Deviations
+
+If a fixture fails byte identity, record it in `tests/unit/round-trip/KNOWN_DEVIATIONS.md` with:
+
+- Fixture name.
+- Input excerpt.
+- Output excerpt.
+- Root cause.
+- Whether the behavior is acceptable for alpha.
+
+Known deviations are allowed only when they are explicit and visible in the generated report.
+
+## Report
+
+`npm run test:roundtrip` should produce `docs/ROUNDTRIP_REPORT.md` with:
+
+- Total fixtures.
+- Passing fixtures.
+- Documented deviations.
+- Unsupported categories.
+- Short explanation of what the result does and does not prove.
+
+The report is part engineering artifact, part public trust proof. Keep it factual.


### PR DESCRIPTION
## Summary

- add the missing June 2026 roadmap source briefs referenced by the generated GitHub issues
- add tracked AI-agent and project constitution docs instead of relying on ignored local-only `CLAUDE.md`/`.specify` files
- add issue backlog conventions and round-trip correctness spec
- link the new docs from `docs/README.md`

Closes #271.

## Verification

- `npx prettier --write ...`
- `npm run format:check`
- `npm run typecheck`

## Notes

This intentionally does not change the MIT/AGPL licensing state. The license decision remains a separate maintainer choice.