### PR TITLE
fix(sync): acknowledge no-op applies so webview edits keep syncing

### DIFF
--- a/docs/superpowers/plans/2026-06-11-save-pipeline-noop-ack.md
+++ b/docs/superpowers/plans/2026-06-11-save-pipeline-noop-ack.md
@@ -1,0 +1,920 @@
+# Save Pipeline Reliability (No-op Apply Ack) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the webview→host sync deadlock so every edit reliably reaches the `TextDocument` (making dirty-state, autosave, save, and hot-exit work), and add unit/integration/e2e tests that lock the whole save chain down.
+
+**Architecture:** Muninn is a `CustomTextEditorProvider`: the `TextDocument` is the source of truth and VS Code owns save/autosave/undo. The webview (ProseMirror) serializes markdown and posts `view.applyDocument`; the host applies it via `workspace.applyEdit`, which fires `onDidChangeTextDocument`, which echoes `host.documentChanged` back — that echo is what releases the webview's `inFlightApply` latch (`src/webview/editor/sync.ts`). **The bug:** when the incoming markdown equals the current document text, `DocumentSync.applyDocument()` returns success *without* applying an edit, so no event fires, no echo is sent, and the latch never releases — every subsequent edit is queued forever and silently dropped. (Empirically confirmed by driving the compiled `HostSyncController`: after one silent no-op, `queueApply` and even `flushApply` never post again.) The fix keeps the view code unchanged and makes the host honor the contract: **every `view.applyDocument` gets a reply** — on a no-op, the host posts the current `host.documentChanged` snapshot. A secondary fix flushes pending edits on webview teardown instead of cancelling them.
+
+**Tech Stack:** TypeScript (strict), mocha + chai (dynamic import) + sinon for unit tests with a mocked `vscode` (`tests/helpers/vscode.js`, loaded via NODE_PATH), `@vscode/test-cli` for integration tests against real VS Code, WebdriverIO + `wdio-vscode-service` for e2e.
+
+**Out of scope (follow-up plan):** the ProseMirror undo-history wipe in `applyHostMarkdown` (`EditorState.create` with a fresh `history()` plugin) and the keystrokes-eaten-during-in-flight-apply race. Both hinge on a pending design decision (rebuild-state vs. transaction-based host updates). This plan only guarantees edits reach the document and saves persist.
+
+**Branch / conflict note:** Execute on a fresh branch off `main` (e.g. `fix/sync-noop-ack`), in its own worktree (use `superpowers:using-git-worktrees`). Open PR #294 touches `src/custom-editor/document-sync.ts` (adds `reconcileTrailingNewlineForApply`); this plan touches the same file in a different region (the `ApplyResult` type and return values). Whichever lands second rebases — the changes are semantically orthogonal.
+
+**Verification commands (used throughout):**
+
+```bash
+npm run coverage          # compiles + runs ALL unit tests with nyc thresholds (80% lines / 70% branches)
+npm run typecheck         # strict tsc on src and tests
+npm run lint              # ESLint + unicorn over src/**/*.ts and tests/**/*.ts
+npm run format            # prettier --write (run before format:check)
+npm run test:integration  # real VS Code instance (compiles + bundles first)
+npm run test:e2e          # WebdriverIO e2e (macOS local)
+```
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/custom-editor/document-sync.ts` | Modify | `ApplyResult` success variant gains `applied: boolean` so callers can tell "edit applied" from "nothing to do" |
+| `src/custom-editor/muninn-custom-editor-provider.ts` | Modify | On a no-op apply, post `host.documentChanged` snapshot so the view latch releases (THE fix) |
+| `src/webview/editor/index.ts` | Modify | `beforeunload` flushes pending edits before disposing the sync controller |
+| `tests/helpers/vscode.js` | Modify | Add `Uri.joinPath` (provider's `getHtml` needs it) |
+| `tests/unit/sync-controller.test.ts` | Create | Unit coverage for the `HostSyncController` state machine (currently zero tests) |
+| `tests/unit/custom-editor-provider.test.ts` | Create | Regression test: no-op apply must be acknowledged; failure path keeps error+snapshot replies |
+| `tests/unit/document-sync.test.ts` | Modify | Update assertions for the `applied` flag |
+| `tests/unit/protocol.test.ts` | Modify | Backfill missing `host.documentChanged` guard cases |
+| `tests/fixtures/save-pipeline.md` | Create | Fixture for save-chain integration test and e2e typing test |
+| `tests/fixtures/save-pipeline-autosave.md` | Create | Separate fixture so the autosave test never sees state from the save test |
+| `tests/integration-cli/save-chain.test.ts` | Create | Real-VS-Code proof: command edit → dirty → save/autosave → bytes on disk |
+| `tests/e2e/save-integrity.e2e.mjs` | Create | Real keystrokes: typing reaches the document, survives a no-op round trip, persists on save |
+| `package.json` | Modify | nyc: re-include `out/src/webview/editor/sync.js` in coverage |
+
+---
+
+### Task 1: Unit coverage for `HostSyncController` (state-machine backfill)
+
+The controller that drives every save has zero tests and is excluded from coverage. These tests pass against current code — they characterize the machine, including the latch behavior that makes the host-side ack mandatory (fixed in Task 3).
+
+**Files:**
+- Create: `tests/unit/sync-controller.test.ts`
+
+- [ ] **Step 1: Write the test file**
+
+```typescript
+import sinon from 'sinon';
+import { HostSyncController, type ApplyDocumentPayload } from '../../src/webview/editor/sync';
+
+let expect: Chai.ExpectStatic;
+
+before(async () => {
+  ({ expect } = await import('chai'));
+});
+
+describe('HostSyncController', () => {
+  let clock: sinon.SinonFakeTimers;
+  let posted: ApplyDocumentPayload[];
+  let controller: HostSyncController;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+    posted = [];
+    controller = new HostSyncController({
+      debounceMs: 80,
+      postApply: (payload) => posted.push(payload),
+    });
+  });
+
+  afterEach(() => {
+    controller.dispose();
+    clock.restore();
+  });
+
+  it('coalesces rapid edits and serializes at flush time', () => {
+    // Production always passes the same serializeMarkdownForHost function; the
+    // debounce timer captures the FIRST closure, so the content that gets
+    // posted is whatever the document holds when the timer fires.
+    let markdown = 'draft one';
+    const getMarkdown = (): string => markdown;
+
+    controller.queueApply(getMarkdown);
+    markdown = 'draft two';
+    controller.queueApply(getMarkdown);
+    expect(posted.length).to.equal(0);
+
+    clock.tick(80);
+    expect(posted).to.deep.equal([{ markdown: 'draft two', revision: 0 }]);
+  });
+
+  it('holds further applies until the host replies, then retries pending edits', () => {
+    controller.queueApply(() => 'first');
+    clock.tick(80);
+    expect(posted.length).to.equal(1);
+
+    controller.queueApply(() => 'second');
+    clock.tick(10_000);
+    expect(posted.length).to.equal(1);
+
+    const shouldRetry = controller.handleHostDocumentChanged(1);
+    expect(shouldRetry).to.equal(true);
+
+    controller.queueApply(() => 'second');
+    clock.tick(80);
+    expect(posted.length).to.equal(2);
+    expect(posted[1]).to.deep.equal({ markdown: 'second', revision: 1 });
+  });
+
+  it('never posts again if the host stays silent after an apply', () => {
+    // Documents the contract the host MUST honor: every view.applyDocument
+    // needs a reply (host.documentChanged or host.error). Without one the
+    // latch below is permanent by design — see the no-op ack in the provider.
+    controller.queueApply(() => 'first');
+    clock.tick(80);
+    expect(posted.length).to.equal(1);
+
+    controller.queueApply(() => 'second');
+    controller.flushApply(() => 'second');
+    clock.tick(60_000);
+    expect(posted.length).to.equal(1);
+  });
+
+  it('flushApply posts pending content immediately and cancels the timer', () => {
+    controller.queueApply(() => 'pending');
+    controller.flushApply(() => 'pending');
+    expect(posted).to.deep.equal([{ markdown: 'pending', revision: 0 }]);
+
+    clock.tick(80);
+    expect(posted.length).to.equal(1);
+  });
+
+  it('flushApply does nothing when no edit is pending', () => {
+    controller.flushApply(() => 'never sent');
+    expect(posted.length).to.equal(0);
+  });
+
+  it('ignores edits queued while sync is suppressed', () => {
+    controller.withSuppressedSync(() => {
+      controller.queueApply(() => 'suppressed');
+    });
+    clock.tick(80);
+    expect(posted.length).to.equal(0);
+  });
+
+  it('handleHostError releases the latch and reports pending work', () => {
+    controller.queueApply(() => 'first');
+    clock.tick(80);
+    controller.queueApply(() => 'second');
+
+    const shouldRetry = controller.handleHostError();
+    expect(shouldRetry).to.equal(true);
+
+    controller.queueApply(() => 'second');
+    clock.tick(80);
+    expect(posted.length).to.equal(2);
+  });
+
+  it('dispose cancels a scheduled apply', () => {
+    controller.queueApply(() => 'pending');
+    controller.dispose();
+    clock.tick(80);
+    expect(posted.length).to.equal(0);
+  });
+
+  it('tracks the host revision in posted payloads', () => {
+    controller.setRevision(7);
+    controller.queueApply(() => 'revisioned');
+    clock.tick(80);
+    expect(posted).to.deep.equal([{ markdown: 'revisioned', revision: 7 }]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the unit suite**
+
+Run: `npm run coverage`
+Expected: PASS — all new `HostSyncController` tests green (they characterize existing behavior). Coverage thresholds still met (sync.js is not yet counted; Task 8 adds it).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/sync-controller.test.ts
+git commit -m "test(sync): characterize HostSyncController state machine"
+```
+
+---
+
+### Task 2: `DocumentSync.applyDocument` reports whether an edit was applied (TDD)
+
+The provider needs to distinguish "applied an edit (echo will fire)" from "no-op (no echo will ever fire)". Add `applied: boolean` to the success variant.
+
+> **Adaptation (executed 2026-06-11):** PR #294 merged before execution, adding `reconcileTrailingNewlineForApply` to this file. That opened a *second* silent no-op path: a serialization differing from the document only by the dropped final newline reconciles back to identical text, then applies a pointless `WorkspaceEdit` whose change-event behavior is VS Code's discretion. The implemented version reconciles **first** and runs the no-op check on the reconciled text, unifying both paths. The #294 test case `'single newline document'` (current `'\n'`, serialized `''`) was updated to expect the no-op (`applied: false`, no edit) instead of an identity edit, and a new test pins the newline-only no-op.
+
+**Files:**
+- Modify: `tests/unit/document-sync.test.ts:87-101` (no-op case), `:103-137` (apply case)
+- Modify: `src/custom-editor/document-sync.ts:4-6`, `:39-41`, `:54`
+
+- [ ] **Step 1: Update the failing assertions**
+
+In `tests/unit/document-sync.test.ts`, change the no-op test (currently asserts `{ ok: true }`):
+
+```typescript
+  it('skips workspace edits when markdown is unchanged and reports the no-op', async () => {
+    const uri = vscode.Uri.file('/workspace/unchanged.md');
+    const document = {
+      uri,
+      getText: () => '# unchanged',
+      lineCount: 1,
+      lineAt: () => ({
+        range: { end: new vscode.Position(0, 11) },
+      }),
+    } as unknown as vscode.TextDocument;
+
+    const sync = new DocumentSync(document);
+    const result = await sync.applyDocument('# unchanged', 0);
+    expect(result).to.deep.equal({ ok: true, applied: false });
+  });
+```
+
+And in `'applies markdown edits and reports host failures'`, change the success assertion:
+
+```typescript
+    const success = await sync.applyDocument('# after', 0);
+    expect(success).to.deep.equal({ ok: true, applied: true });
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npm run coverage`
+Expected: FAIL — two `deep.equal` mismatches: `{ ok: true }` does not equal `{ ok: true, applied: false }` / `{ ok: true, applied: true }`.
+
+- [ ] **Step 3: Implement the `applied` flag**
+
+In `src/custom-editor/document-sync.ts`, change the result type:
+
+```typescript
+type ApplyResult =
+  | { ok: true; applied: boolean }
+  | { ok: false; code: 'revision_mismatch' | 'apply_failed'; message: string };
+```
+
+Replace the unchanged-markdown early return with a unified check on the *reconciled* markdown (this also covers the newline-only no-op introduced by #294's reconcile):
+
+```typescript
+    // Reconcile BEFORE the no-op check: a serialization that differs from the
+    // document only by the dropped final newline reconciles back to identical
+    // text, and applying that edit would be a no-op whose change-event
+    // behavior is up to VS Code. Callers rely on `applied` to know whether an
+    // onDidChangeTextDocument echo will follow.
+    const markdownToApply = reconcileTrailingNewlineForApply(this.document.getText(), markdown);
+    if (markdownToApply === this.document.getText()) {
+      return { ok: true, applied: false };
+    }
+```
+
+Change the final return:
+
+```typescript
+    return { ok: true, applied: true };
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npm run coverage && npm run typecheck`
+Expected: PASS on both. The provider compiles unchanged — it only narrows on `applyResult.ok`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/custom-editor/document-sync.ts tests/unit/document-sync.test.ts
+git commit -m "feat(sync): report whether applyDocument applied a workspace edit"
+```
+
+---
+
+### Task 3: Provider acknowledges no-op applies — THE deadlock fix (TDD)
+
+**Files:**
+- Modify: `tests/helpers/vscode.js:3-23` (add `Uri.joinPath`)
+- Create: `tests/unit/custom-editor-provider.test.ts`
+- Modify: `src/custom-editor/muninn-custom-editor-provider.ts:186-205`
+
+- [ ] **Step 1: Add `Uri.joinPath` to the vscode mock**
+
+The provider's `resolveCustomTextEditor` builds webview HTML via `vscode.Uri.joinPath`, which the mock lacks. In `tests/helpers/vscode.js`, add at the top (line 1 area):
+
+```javascript
+const fs = require('fs').promises;
+const path = require('path');
+```
+
+And inside `class Uri`, after `static parse(value)`:
+
+```javascript
+  static joinPath(base, ...segments) {
+    return Uri.file(path.posix.join(base.fsPath, ...segments));
+  }
+```
+
+- [ ] **Step 2: Write the failing regression test**
+
+Create `tests/unit/custom-editor-provider.test.ts`:
+
+```typescript
+import * as vscode from 'vscode';
+import { MuninnCustomEditorProvider } from '../../src/custom-editor/muninn-custom-editor-provider';
+import type { HostToViewMessage } from '../../src/custom-editor/protocol';
+import type { ConfigService } from '../../src/services/config-service';
+import type { Logger } from '../../src/services/logger';
+
+let expect: Chai.ExpectStatic;
+
+before(async () => {
+  ({ expect } = await import('chai'));
+});
+
+type FakePanel = {
+  panel: vscode.WebviewPanel;
+  posted: HostToViewMessage[];
+  sendViewMessage: (message: unknown) => Promise<void>;
+};
+
+const createFakePanel = (): FakePanel => {
+  const posted: HostToViewMessage[] = [];
+  let messageListener: ((message: unknown) => Promise<void> | void) | undefined;
+
+  const panel = {
+    webview: {
+      options: {},
+      html: '',
+      cspSource: 'vscode-webview-resource:',
+      asWebviewUri: (uri: vscode.Uri) => uri,
+      onDidReceiveMessage: (listener: (message: unknown) => Promise<void> | void) => {
+        messageListener = listener;
+        return { dispose: () => {} };
+      },
+      postMessage: async (message: HostToViewMessage) => {
+        posted.push(message);
+        return true;
+      },
+    },
+    onDidDispose: () => ({ dispose: () => {} }),
+  } as unknown as vscode.WebviewPanel;
+
+  return {
+    panel,
+    posted,
+    sendViewMessage: async (message: unknown) => {
+      await messageListener?.(message);
+    },
+  };
+};
+
+const createMarkdownDocument = (text: string): vscode.TextDocument =>
+  ({
+    uri: vscode.Uri.file('/workspace/noop.md'),
+    getText: () => text,
+    lineCount: 1,
+    lineAt: () => ({
+      range: { end: new vscode.Position(0, text.length) },
+    }),
+  }) as unknown as vscode.TextDocument;
+
+describe('MuninnCustomEditorProvider view.applyDocument handling', () => {
+  const workspaceWithApplyEdit = vscode.workspace as unknown as {
+    applyEdit?: (edit: vscode.WorkspaceEdit) => Promise<boolean>;
+  };
+  const originalApplyEdit = workspaceWithApplyEdit.applyEdit;
+  let provider: MuninnCustomEditorProvider;
+
+  beforeEach(() => {
+    provider = new MuninnCustomEditorProvider(
+      vscode.Uri.file('/extension'),
+      {} as unknown as ConfigService,
+      { warn: () => {}, info: () => {}, error: () => {} } as unknown as Logger,
+    );
+  });
+
+  afterEach(() => {
+    provider.dispose();
+    workspaceWithApplyEdit.applyEdit = originalApplyEdit;
+  });
+
+  it('acknowledges a no-op apply with a documentChanged snapshot', async () => {
+    const { panel, posted, sendViewMessage } = createFakePanel();
+    await provider.resolveCustomTextEditor(createMarkdownDocument('# unchanged'), panel);
+
+    await sendViewMessage({
+      type: 'view.applyDocument',
+      payload: { markdown: '# unchanged', revision: 0 },
+    });
+
+    // Without this reply the webview's inFlightApply latch never releases and
+    // every subsequent edit is dropped (the autosave/data-loss deadlock).
+    expect(posted).to.deep.equal([
+      {
+        type: 'host.documentChanged',
+        payload: { markdown: '# unchanged', revision: 0 },
+      },
+    ]);
+  });
+
+  it('posts nothing extra when an edit is applied (the document event echoes instead)', async () => {
+    workspaceWithApplyEdit.applyEdit = async () => true;
+    const { panel, posted, sendViewMessage } = createFakePanel();
+    await provider.resolveCustomTextEditor(createMarkdownDocument('# before'), panel);
+
+    await sendViewMessage({
+      type: 'view.applyDocument',
+      payload: { markdown: '# after', revision: 0 },
+    });
+
+    expect(posted).to.deep.equal([]);
+  });
+
+  it('replies with host.error and a snapshot when the apply fails', async () => {
+    workspaceWithApplyEdit.applyEdit = async () => false;
+    const { panel, posted, sendViewMessage } = createFakePanel();
+    await provider.resolveCustomTextEditor(createMarkdownDocument('# before'), panel);
+
+    await sendViewMessage({
+      type: 'view.applyDocument',
+      payload: { markdown: '# after', revision: 0 },
+    });
+
+    expect(posted).to.deep.equal([
+      {
+        type: 'host.error',
+        payload: {
+          code: 'apply_failed',
+          message: 'VS Code failed to apply the markdown update.',
+        },
+      },
+      {
+        type: 'host.documentChanged',
+        payload: { markdown: '# before', revision: 0 },
+      },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 3: Run to verify the right failure**
+
+Run: `npm run coverage`
+Expected: FAIL — exactly one test: `'acknowledges a no-op apply with a documentChanged snapshot'` (posted is `[]`, expected one `host.documentChanged`). The other two provider tests PASS (they assert existing behavior).
+
+- [ ] **Step 4: Implement the no-op ack**
+
+In `src/custom-editor/muninn-custom-editor-provider.ts`, replace the `'view.applyDocument'` case (lines 186-205) with:
+
+```typescript
+      case 'view.applyDocument': {
+        const applyResult = await session.sync.applyDocument(
+          message.payload.markdown,
+          message.payload.revision,
+        );
+        if (!applyResult.ok) {
+          await this.postMessage(session.panel.webview, {
+            type: 'host.error',
+            payload: {
+              code: applyResult.code,
+              message: applyResult.message,
+            },
+          });
+          await this.postMessage(session.panel.webview, {
+            type: 'host.documentChanged',
+            payload: session.sync.getSnapshot(),
+          });
+          return;
+        }
+        if (!applyResult.applied) {
+          // No workspace edit was needed, so no onDidChangeTextDocument echo
+          // will fire. Reply with the snapshot anyway: the webview sync
+          // controller stays latched until the host answers every apply.
+          await this.postMessage(session.panel.webview, {
+            type: 'host.documentChanged',
+            payload: session.sync.getSnapshot(),
+          });
+        }
+        return;
+      }
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `npm run coverage && npm run typecheck && npm run lint`
+Expected: PASS on all three.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/helpers/vscode.js tests/unit/custom-editor-provider.test.ts src/custom-editor/muninn-custom-editor-provider.ts
+git commit -m "fix(sync): acknowledge no-op applies so webview edits keep syncing"
+```
+
+---
+
+### Task 4: Backfill `host.documentChanged` protocol guard tests
+
+`tests/unit/protocol.test.ts` covers every host message except the one that releases the sync latch.
+
+**Files:**
+- Modify: `tests/unit/protocol.test.ts:49-85` and `:87-113`
+
+- [ ] **Step 1: Add the missing guard assertions**
+
+In `'accepts valid host-to-view payloads'`, add after the `host.init` expectation:
+
+```typescript
+    expect(
+      isHostToViewMessage({
+        type: 'host.documentChanged',
+        payload: { markdown: '# doc', revision: 2 },
+      }),
+    ).to.equal(true);
+```
+
+In `'rejects malformed host-to-view payloads'`, add after the `host.init` rejections:
+
+```typescript
+    expect(
+      isHostToViewMessage({
+        type: 'host.documentChanged',
+        payload: { markdown: '# doc' },
+      }),
+    ).to.equal(false);
+    expect(
+      isHostToViewMessage({
+        type: 'host.documentChanged',
+        payload: { markdown: 42, revision: 1 },
+      }),
+    ).to.equal(false);
+```
+
+- [ ] **Step 2: Run to verify pass**
+
+Run: `npm run coverage`
+Expected: PASS (the guard already implements this — the test was simply missing).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/protocol.test.ts
+git commit -m "test(protocol): cover host.documentChanged guard"
+```
+
+---
+
+### Task 5: Flush pending edits on webview teardown
+
+`beforeunload` currently calls `syncController.dispose()`, which *cancels* a scheduled apply — silently dropping the last ≤80 ms of typing on tab close. Flush first (best-effort: message delivery during unload is not guaranteed by VS Code, but the common case — an idle pending timer — is saved). `flushApply` is already covered by Task 1's unit tests; the wiring itself has no automated test because `index.ts` is DOM-bound (it is bundled for the webview and excluded from unit coverage).
+
+**Files:**
+- Modify: `src/webview/editor/index.ts:830-834`
+
+- [ ] **Step 1: Add the flush**
+
+Replace the `beforeunload` listener:
+
+```typescript
+window.addEventListener('beforeunload', () => {
+  syncController.flushApply(serializeMarkdownForHost);
+  detachHostMessageListener();
+  syncController.dispose();
+  mermaidPreview.dispose();
+});
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `npm run typecheck && npm run bundle && npm run lint`
+Expected: PASS on all three.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/webview/editor/index.ts
+git commit -m "fix(webview): flush pending edits before webview teardown"
+```
+
+---
+
+### Task 6: Integration tests — dirty → save → disk, and autosave (real VS Code)
+
+Proves the chain the user reported broken, against a real `TextDocument` (the unit mocks cannot catch dirty/save behavior). These tests pass even before Task 3 — they cover the non-no-op chain and pin it against regressions.
+
+**Files:**
+- Create: `tests/fixtures/save-pipeline.md`
+- Create: `tests/fixtures/save-pipeline-autosave.md`
+- Create: `tests/integration-cli/save-chain.test.ts`
+
+- [ ] **Step 1: Create the fixtures**
+
+`tests/fixtures/save-pipeline.md` (with a trailing newline):
+
+```markdown
+# Save Pipeline
+
+Alpha bravo charlie delta.
+```
+
+`tests/fixtures/save-pipeline-autosave.md` (with a trailing newline):
+
+```markdown
+# Autosave Pipeline
+
+Echo foxtrot golf hotel.
+```
+
+- [ ] **Step 2: Write the integration test**
+
+Create `tests/integration-cli/save-chain.test.ts` (mirrors the retry/waitFor patterns of `core-workflow.test.ts` — command-driven edits need retries because webview readiness is asynchronous):
+
+```typescript
+import * as vscode from 'vscode';
+
+let expect: Chai.ExpectStatic;
+
+before(async () => {
+  ({ expect } = await import('chai'));
+});
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+const waitFor = async (
+  predicate: () => boolean,
+  timeoutMs = 15_000,
+  intervalMs = 100,
+): Promise<void> => {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) {
+      return;
+    }
+    await sleep(intervalMs);
+  }
+  throw new Error('Timed out waiting for save chain condition.');
+};
+
+const getActiveCustomViewType = (): string | undefined => {
+  const tab = vscode.window.tabGroups.activeTabGroup.activeTab;
+  if (!tab) {
+    return undefined;
+  }
+  if (tab.input instanceof vscode.TabInputCustom) {
+    return tab.input.viewType;
+  }
+  return undefined;
+};
+
+const openInCustomEditor = async (fileName: string): Promise<vscode.TextDocument> => {
+  const extension = vscode.extensions.getExtension('blueclouddev.muninn-vscode');
+  expect(extension).to.not.equal(undefined);
+  await extension?.activate();
+
+  const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+  expect(workspaceFolder, 'expected integration workspace folder').to.not.equal(undefined);
+
+  const uri = vscode.Uri.joinPath(workspaceFolder!.uri, fileName);
+  const document = await vscode.workspace.openTextDocument(uri);
+  await vscode.commands.executeCommand('vscode.open', uri);
+  await waitFor(() => getActiveCustomViewType() === 'muninn.markdownEditor');
+  return document;
+};
+
+const insertMermaidUntilApplied = async (document: vscode.TextDocument): Promise<void> => {
+  let inserted = false;
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    await vscode.commands.executeCommand('muninn.insertMermaidBlock');
+    await sleep(250);
+    if (document.getText().includes('```mermaid')) {
+      inserted = true;
+      break;
+    }
+  }
+  expect(inserted, 'expected mermaid block to be inserted via webview round trip').to.equal(true);
+};
+
+const readDiskText = async (document: vscode.TextDocument): Promise<string> => {
+  const bytes = await vscode.workspace.fs.readFile(document.uri);
+  return new TextDecoder().decode(bytes);
+};
+
+describe('Integration CLI: save chain', () => {
+  it('marks the document dirty after a webview edit and persists it on save', async () => {
+    const document = await openInCustomEditor('save-pipeline.md');
+
+    await insertMermaidUntilApplied(document);
+    expect(document.isDirty, 'webview edit must dirty the TextDocument').to.equal(true);
+
+    await vscode.commands.executeCommand('workbench.action.files.save');
+    await waitFor(() => !document.isDirty);
+
+    const diskText = await readDiskText(document);
+    expect(diskText).to.include('```mermaid');
+    expect(diskText).to.include('Alpha bravo charlie delta.');
+  });
+
+  it('persists webview edits through autosave without an explicit save', async () => {
+    const filesConfiguration = vscode.workspace.getConfiguration('files');
+    await filesConfiguration.update('autoSave', 'afterDelay', vscode.ConfigurationTarget.Global);
+    await filesConfiguration.update('autoSaveDelay', 200, vscode.ConfigurationTarget.Global);
+
+    try {
+      const document = await openInCustomEditor('save-pipeline-autosave.md');
+
+      await insertMermaidUntilApplied(document);
+      await waitFor(() => !document.isDirty);
+
+      const diskText = await readDiskText(document);
+      expect(diskText).to.include('```mermaid');
+      expect(diskText).to.include('Echo foxtrot golf hotel.');
+    } finally {
+      await filesConfiguration.update('autoSave', 'off', vscode.ConfigurationTarget.Global);
+      await filesConfiguration.update('autoSaveDelay', undefined, vscode.ConfigurationTarget.Global);
+    }
+  });
+});
+```
+
+- [ ] **Step 3: Run the integration suite**
+
+Run: `npm run test:integration`
+Expected: PASS — both new tests green alongside the existing activation/commands/core-workflow tests. (The test VS Code instance uses a fresh `--user-data-dir` per run, so the Global autosave setting cannot leak outside the run; the `finally` restores it within the run.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/fixtures/save-pipeline.md tests/fixtures/save-pipeline-autosave.md tests/integration-cli/save-chain.test.ts
+git commit -m "test(integration): cover dirty-state, save, and autosave persistence"
+```
+
+---
+
+### Task 7: E2E — real keystrokes survive a no-op round trip and persist
+
+This is the user's bug as a spec: type, trigger a no-op apply (char + immediate backspace inside the 80 ms debounce window), keep typing, save, verify disk bytes. Pre-fix, phase 2 deadlocks and the test fails on timeout; post-fix it passes. (Timing caveat: if WebDriver delivers the char and backspace more than 80 ms apart, the no-op window is missed and the test degrades to a plain typing check — the *deterministic* deadlock guard is Task 3's unit test; this spec is the end-to-end safety net. `browser.keys(['x', 'Backspace'])` sends both in one WebDriver action to keep the gap in single-digit milliseconds.)
+
+**Files:**
+- Create: `tests/e2e/save-integrity.e2e.mjs`
+
+- [ ] **Step 1: Write the e2e spec**
+
+```javascript
+import { expect, browser } from '@wdio/globals';
+import {
+  openWorkspaceFile,
+  waitForCustomEditor,
+  waitForCustomEditorWebviewReady,
+  waitForWorkspaceFileText,
+  withCustomEditorWebview,
+} from './helpers.mjs';
+
+const typeInProseMirror = async (keys) => {
+  await withCustomEditorWebview(async () => {
+    const editor = await browser.$('.ProseMirror');
+    await editor.waitForDisplayed({ timeout: 5_000 });
+    await editor.click();
+    await browser.keys(['End']);
+    await browser.keys(keys);
+  });
+};
+
+const readDiskText = async (fileName) =>
+  browser.executeWorkbench(async (vscode, relativeFileName) => {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    if (!workspaceFolder) {
+      throw new Error('No workspace folder available in VS Code test session.');
+    }
+    const uri = vscode.Uri.joinPath(workspaceFolder.uri, relativeFileName);
+    const bytes = await vscode.workspace.fs.readFile(uri);
+    return new TextDecoder().decode(bytes);
+  }, fileName);
+
+describe('Save integrity', () => {
+  it('keeps syncing keystrokes after a no-op apply and persists them on save', async () => {
+    await openWorkspaceFile('save-pipeline.md');
+    await waitForCustomEditor('save-pipeline.md');
+    await waitForCustomEditorWebviewReady();
+
+    await typeInProseMirror('zulu');
+    await waitForWorkspaceFileText(
+      'save-pipeline.md',
+      (text) => text.includes('zulu'),
+      'Expected typed text to reach the host document.',
+      { attempts: 25, interval: 200 },
+    );
+
+    // Char + immediate backspace serializes to unchanged markdown -> the host
+    // treats the apply as a no-op. Typing afterwards must still sync.
+    await typeInProseMirror(['x', 'Backspace']);
+    await typeInProseMirror('yankee');
+    await waitForWorkspaceFileText(
+      'save-pipeline.md',
+      (text) => text.includes('yankee'),
+      'Expected keystrokes after a no-op apply to keep reaching the host document.',
+      { attempts: 25, interval: 200 },
+    );
+
+    await browser.executeWorkbench(async (vscode) => {
+      await vscode.commands.executeCommand('workbench.action.files.save');
+    });
+
+    await browser.waitUntil(
+      async () => {
+        const diskText = await readDiskText('save-pipeline.md');
+        return diskText.includes('zulu') && diskText.includes('yankee');
+      },
+      {
+        timeout: 10_000,
+        timeoutMsg: 'Expected saved file on disk to contain all typed text.',
+      },
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the e2e suite locally**
+
+Run: `npm run test:e2e`
+Expected: PASS — `save-integrity.e2e.mjs` green alongside the existing 8 specs. (Note `readWorkspaceFileText`/`waitForWorkspaceFileText` read the live `TextDocument`, which is why the disk assertion uses `workspace.fs.readFile` after an explicit save.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/save-integrity.e2e.mjs
+git commit -m "test(e2e): guard keystroke-to-disk save integrity through no-op applies"
+```
+
+---
+
+### Task 8: Enforce coverage for the sync controller
+
+`nyc` excludes all of `out/src/webview/**`, which is how a 96-line state machine carrying every save shipped with zero enforced coverage. Re-include just `sync.js` (now fully covered by Task 1). `test-exclude` (nyc's matcher) supports negated patterns in `exclude`.
+
+**Files:**
+- Modify: `package.json:485-491` (the `nyc.exclude` array)
+
+- [ ] **Step 1: Add the negated exclude**
+
+In `package.json`, change the nyc `exclude` array to:
+
+```json
+    "exclude": [
+      "**/*.d.ts",
+      "tests/**",
+      "out/src/types/config.js",
+      "out/src/custom-editor/muninn-custom-editor-provider.js",
+      "out/src/webview/**",
+      "!out/src/webview/editor/sync.js"
+    ],
+```
+
+- [ ] **Step 2: Verify coverage picks it up and thresholds hold**
+
+Run: `npm run coverage`
+Expected: PASS — the text report now lists `webview/editor/sync.js` with ~100% lines/branches (Task 1 exercises every path), and the global 80/70 thresholds still pass. If `sync.js` does NOT appear in the report, the negation was not honored — stop and check the installed nyc/test-exclude version rather than lowering thresholds (AGENTS.md forbids lowering them).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json
+git commit -m "chore(coverage): enforce coverage for the webview sync controller"
+```
+
+---
+
+### Task 9: Full gate verification
+
+No new code — prove the branch is green on every gate the CI runs (`gate-linux`: lint → format → typecheck → coverage → integration; `e2e-macos`: wdio).
+
+- [ ] **Step 1: Format and run all local gates**
+
+```bash
+npm run format
+npm run format:check && npm run lint && npm run typecheck && npm run coverage && npm run test:integration
+```
+
+Expected: all PASS. If `npm run format` changed any files, inspect the diff (it should only be formatting), then amend them into a final commit:
+
+```bash
+git add -A
+git commit -m "chore: prettier formatting for save-pipeline test files" || true
+```
+
+- [ ] **Step 2: Run e2e**
+
+Run: `npm run test:e2e`
+Expected: PASS (macOS local). Known context: the e2e lane has a history of unrelated flakiness (issue #280) — a failure in `accessibility-toolbar.e2e.mjs` or similar is pre-existing; a failure in `save-integrity.e2e.mjs` is yours.
+
+- [ ] **Step 3: Verify the round-trip suite is untouched**
+
+This plan changes no schema/parser/serializer code (AGENTS.md prime directive). Confirm:
+
+```bash
+npm run test:roundtrip
+git status --short docs/ROUNDTRIP_REPORT.md docs/KNOWN_DEVIATIONS.md
+```
+
+Expected: report regenerates with no diff (clean `git status` for both docs).
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** deadlock fix (Tasks 2–3), teardown data loss (Task 5), "make sure save works" test layers: state machine (Task 1), protocol (Task 4), real dirty/save/autosave (Task 6), keystrokes→disk e2e (Task 7), coverage enforcement (Task 8). Undo-history wipe and in-flight keystroke race intentionally out of scope (documented in header).
+- **Type consistency:** `ApplyResult` success variant `{ ok: true; applied: boolean }` is defined in Task 2 and consumed via `applyResult.applied` in Task 3; provider tests assert payload shapes that match `SerializedMarkdownPayload` (`markdown`/`revision`).
+- **Known judgment calls:** the e2e no-op window is timing-dependent (documented in Task 7 — Task 3's unit test is the deterministic guard); the `beforeunload` flush is best-effort by platform design (documented in Task 5).

--- a/package-lock.json
+++ b/package-lock.json
@@ -288,6 +288,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2232,7 +2233,6 @@
       "integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -2256,7 +2256,6 @@
       "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -2267,7 +2266,6 @@
       "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "jest-regex-util": "30.0.1"
@@ -3332,6 +3330,7 @@
       "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.21.0"
       }
@@ -3478,6 +3477,7 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -3735,7 +3735,6 @@
       "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "4.1.6",
         "convert-source-map": "^2.0.0",
@@ -3751,7 +3750,6 @@
       "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tinyrainbow": "^3.1.0"
       },
@@ -3764,8 +3762,7 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@vitest/utils/node_modules/tinyrainbow": {
       "version": "3.1.0",
@@ -3773,7 +3770,6 @@
       "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -4459,7 +4455,6 @@
       "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -4470,7 +4465,6 @@
       "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0"
       },
@@ -4484,7 +4478,6 @@
       "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "jest-regex-util": "30.4.0"
@@ -4499,7 +4492,6 @@
       "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -4513,7 +4505,6 @@
       "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/pattern": "30.4.0",
         "@jest/schemas": "30.4.1",
@@ -4533,7 +4524,6 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4572,8 +4562,7 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
       "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@wdio/cli/node_modules/@types/node": {
       "version": "20.19.41",
@@ -4598,7 +4587,6 @@
       "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tinyrainbow": "^3.1.0"
       },
@@ -4631,6 +4619,7 @@
       "integrity": "sha512-jm6gTQ6Qo3EOBY6PA09U/5Pf17WLEJM1/lTfhc6jzLFE770EuhuhbuphqrInH0hVR9WMyWtSZQ+LRCcLfcmOPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.20.0"
       },
@@ -4653,6 +4642,7 @@
       "integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^5.1.2",
         "loglevel": "^1.6.0",
@@ -4812,7 +4802,6 @@
       "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/expect-utils": "30.4.1",
         "@jest/get-type": "30.1.0",
@@ -4831,7 +4820,6 @@
       "integrity": "sha512-5ot+Apo0bEvMD/nqzWymQpgyWnOdu0kVpmahLx5T7NzUc6RyifucZ24Gsfr6F6C8yRGBhmoFh7ZeY+W9kteEBQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/snapshot": "^4.0.16",
         "deep-eql": "^5.0.2",
@@ -4864,7 +4852,6 @@
       "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "4.1.6",
         "@vitest/utils": "4.1.6",
@@ -5004,7 +4991,6 @@
       "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/diff-sequences": "30.4.0",
         "@jest/get-type": "30.1.0",
@@ -5021,7 +5007,6 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -5039,7 +5024,6 @@
       "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
@@ -5056,7 +5040,6 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -5074,7 +5057,6 @@
       "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@jest/types": "30.4.1",
@@ -5097,7 +5079,6 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -5115,7 +5096,6 @@
       "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.4.1",
         "@types/node": "*",
@@ -5131,7 +5111,6 @@
       "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -5142,7 +5121,6 @@
       "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.4.1",
         "@types/node": "*",
@@ -5161,7 +5139,6 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -5218,8 +5195,7 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@wdio/cli/node_modules/picomatch": {
       "version": "4.0.4",
@@ -5227,7 +5203,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5241,7 +5216,6 @@
       "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "30.4.1",
         "ansi-styles": "^5.2.0",
@@ -5258,7 +5232,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5374,7 +5347,6 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5442,7 +5414,6 @@
       "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -5493,6 +5464,7 @@
       "integrity": "sha512-iPaIU/DluYY7zfLiwXDdoLU/6ZW8eup4PNwQikrCzTfvH/ITllRhFUe6NRDTEEePSxxRTeXAn9nehCs98xWGVA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "^20.11.30",
         "@types/sinonjs__fake-timers": "^8.1.5",
@@ -6526,6 +6498,7 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8826,6 +8799,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -9235,6 +9209,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9391,7 +9366,6 @@
       "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -10074,6 +10048,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -12667,7 +12642,6 @@
       "integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.2.0",
         "@types/node": "*",
@@ -12683,7 +12657,6 @@
       "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -12697,7 +12670,6 @@
       "integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/pattern": "30.0.1",
         "@jest/schemas": "30.0.5",
@@ -12716,8 +12688,7 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
       "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jest-mock/node_modules/jest-util": {
       "version": "30.2.0",
@@ -12725,7 +12696,6 @@
       "integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.2.0",
         "@types/node": "*",
@@ -12744,7 +12714,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12758,7 +12727,6 @@
       "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -15387,6 +15355,7 @@
       "integrity": "sha512-ArbnyA3U5SGHokEvkfWjW+O8hOxV1RSJxOgriX/3A4xZRqixt9ZFHD0yPgZQF05Qj0oAqi8H/7stDorjoHY90Q==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@puppeteer/browsers": "1.9.1",
         "chromium-bidi": "0.5.8",
@@ -15579,8 +15548,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-is-19": {
       "name": "react-is",
@@ -15588,8 +15556,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
       "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/read": {
       "version": "1.0.7",
@@ -17347,6 +17314,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18120,6 +18088,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18431,7 +18400,6 @@
       "integrity": "sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0"
       },
@@ -18445,7 +18413,6 @@
       "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -18459,7 +18426,6 @@
       "integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/pattern": "30.0.1",
         "@jest/schemas": "30.0.5",
@@ -18479,7 +18445,6 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -18497,7 +18462,6 @@
       "integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "extract-zip": "^2.0.1",
@@ -18519,8 +18483,7 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
       "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/wdio-video-reporter/node_modules/@types/node": {
       "version": "20.19.33",
@@ -18537,8 +18500,7 @@
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
       "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/wdio-video-reporter/node_modules/@vitest/pretty-format": {
       "version": "4.0.18",
@@ -18546,7 +18508,6 @@
       "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tinyrainbow": "^3.0.3"
       },
@@ -18560,7 +18521,6 @@
       "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "4.0.18",
         "magic-string": "^0.30.21",
@@ -18576,7 +18536,6 @@
       "integrity": "sha512-rcHu0eG16rSEmHL0sEKDcr/vYFmGhQ5GOlmlx54r+1sgh6sf136q+kth4169s16XqviWGW3LjZbUfpTK29pGtw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@wdio/logger": "9.18.0",
         "@wdio/types": "9.24.0",
@@ -18597,7 +18556,6 @@
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -18619,6 +18577,7 @@
       "integrity": "sha512-OmwPKV8c5ecLqo+EkytN7oUeYfNmRI4uOXGIR1ybP7AK5Zz+l9R0dGfoadEuwi1aZXAL0vwuhtq3p0OL3dfqHQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.20.0"
       },
@@ -18641,6 +18600,7 @@
       "integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^5.1.2",
         "loglevel": "^1.6.0",
@@ -18657,8 +18617,7 @@
       "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.24.0.tgz",
       "integrity": "sha512-ozQKYddBLT4TRvU9J+fGrhVUtx3iDAe+KNCJcTDMFMxNSdDMR2xFQdNp8HLHypspk58oXTYCvz6ZYjySthhqsw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/wdio-video-reporter/node_modules/@wdio/repl": {
       "version": "9.16.2",
@@ -18666,7 +18625,6 @@
       "integrity": "sha512-FLTF0VL6+o5BSTCO7yLSXocm3kUnu31zYwzdsz4n9s5YWt83sCtzGZlZpt7TaTzb3jVUfxuHNQDTb8UMkCu0lQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "^20.1.0"
       },
@@ -18710,7 +18668,6 @@
       "integrity": "sha512-6WhtzC5SNCGRBTkaObX6A07Ofnnyyf+TQH/d/fuhZRqvBknrP4AMMZF+PFxGl1fwdySWdBn+gV2QLE+52Byowg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@puppeteer/browsers": "^2.2.0",
         "@wdio/logger": "9.18.0",
@@ -18750,7 +18707,6 @@
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -18774,7 +18730,6 @@
       "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -18788,7 +18743,6 @@
       "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=16.0.0"
       }
@@ -18810,7 +18764,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@wdio/logger": "^9.18.0",
         "@zip.js/zip.js": "^2.8.11",
@@ -18834,7 +18787,6 @@
       "integrity": "sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/expect-utils": "30.2.0",
         "@jest/get-type": "30.1.0",
@@ -18892,7 +18844,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "strnum": "^2.1.2"
       },
@@ -18906,7 +18857,6 @@
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
@@ -18925,7 +18875,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@wdio/logger": "^9.18.0",
         "@zip.js/zip.js": "^2.8.11",
@@ -18947,7 +18896,6 @@
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18961,7 +18909,6 @@
       "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -18972,7 +18919,6 @@
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -18989,7 +18935,6 @@
       "integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/diff-sequences": "30.0.1",
         "@jest/get-type": "30.1.0",
@@ -19006,7 +18951,6 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -19024,7 +18968,6 @@
       "integrity": "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
@@ -19041,7 +18984,6 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -19059,7 +19001,6 @@
       "integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@jest/types": "30.2.0",
@@ -19081,7 +19022,6 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -19099,7 +19039,6 @@
       "integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.2.0",
         "@types/node": "*",
@@ -19118,7 +19057,6 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -19136,7 +19074,6 @@
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -19147,7 +19084,6 @@
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -19164,7 +19100,6 @@
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -19181,16 +19116,14 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/wdio-video-reporter/node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/wdio-video-reporter/node_modules/picomatch": {
       "version": "4.0.3",
@@ -19198,7 +19131,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19212,7 +19144,6 @@
       "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "30.0.5",
         "ansi-styles": "^5.2.0",
@@ -19228,7 +19159,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -19242,7 +19172,6 @@
       "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -19273,7 +19202,6 @@
       "integrity": "sha512-jkg4434cYgtrIF2AeY/X0Wmd2W73cK5qIEFE3hDrrQenJH/2SDJIXGvPAigfvQTcE9+H31zkiNHbUqcihEiMRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -19304,7 +19232,6 @@
       "integrity": "sha512-ZYkZLAvKTKQXWuh5XpBw7CdbSzagarX39WyZ2H07CDLC5/KfsRGlIXV8d4+tfqX1M7916mRqR1QfNHSij+c9Pw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "type-fest": "^4.31.0"
       },
@@ -19321,7 +19248,6 @@
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -19335,7 +19261,6 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -19367,8 +19292,7 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/wdio-video-reporter/node_modules/tar-fs": {
       "version": "3.1.1",
@@ -19376,7 +19300,6 @@
       "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"
@@ -19392,7 +19315,6 @@
       "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
@@ -19405,7 +19327,6 @@
       "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -19416,7 +19337,6 @@
       "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.17"
       }
@@ -19434,7 +19354,6 @@
       "integrity": "sha512-2R31Ey83NzMsafkl4hdFq6GlIBvOODQMkueLjeRqYAITu3QCYiq9oqBdnWA6CdePuV4dbKlYsKRX0mwMiPclDA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "^20.1.0",
         "@types/ws": "^8.5.3",
@@ -19504,7 +19423,6 @@
       "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "isexe": "^4.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -488,7 +488,8 @@
       "tests/**",
       "out/src/types/config.js",
       "out/src/custom-editor/muninn-custom-editor-provider.js",
-      "out/src/webview/**"
+      "out/src/webview/**",
+      "!out/src/webview/editor/sync.js"
     ],
     "reporter": [
       "text",

--- a/src/custom-editor/document-sync.ts
+++ b/src/custom-editor/document-sync.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { SerializedMarkdownPayload } from './protocol';
 
 type ApplyResult =
-  | { ok: true }
+  | { ok: true; applied: boolean }
   | { ok: false; code: 'revision_mismatch' | 'apply_failed'; message: string };
 
 export const reconcileTrailingNewlineForApply = (
@@ -44,11 +44,16 @@ export class DocumentSync {
       };
     }
 
-    if (markdown === this.document.getText()) {
-      return { ok: true };
+    // Reconcile BEFORE the no-op check: a serialization that differs from the
+    // document only by the dropped final newline reconciles back to identical
+    // text, and applying that edit would be a no-op whose change-event
+    // behavior is up to VS Code. Callers rely on `applied` to know whether an
+    // onDidChangeTextDocument echo will follow.
+    const markdownToApply = reconcileTrailingNewlineForApply(this.document.getText(), markdown);
+    if (markdownToApply === this.document.getText()) {
+      return { ok: true, applied: false };
     }
 
-    const markdownToApply = reconcileTrailingNewlineForApply(this.document.getText(), markdown);
     const workspaceEdit = new vscode.WorkspaceEdit();
     workspaceEdit.replace(this.document.uri, this.getFullRange(), markdownToApply);
     const applied = await vscode.workspace.applyEdit(workspaceEdit);
@@ -60,7 +65,7 @@ export class DocumentSync {
       };
     }
 
-    return { ok: true };
+    return { ok: true, applied: true };
   }
 
   private getFullRange(): vscode.Range {

--- a/src/custom-editor/muninn-custom-editor-provider.ts
+++ b/src/custom-editor/muninn-custom-editor-provider.ts
@@ -200,6 +200,16 @@ export class MuninnCustomEditorProvider
             type: 'host.documentChanged',
             payload: session.sync.getSnapshot(),
           });
+          return;
+        }
+        if (!applyResult.applied) {
+          // No workspace edit was needed, so no onDidChangeTextDocument echo
+          // will fire. Reply with the snapshot anyway: the webview sync
+          // controller stays latched until the host answers every apply.
+          await this.postMessage(session.panel.webview, {
+            type: 'host.documentChanged',
+            payload: session.sync.getSnapshot(),
+          });
         }
         return;
       }

--- a/src/webview/editor/index.ts
+++ b/src/webview/editor/index.ts
@@ -830,6 +830,9 @@ const detachHostMessageListener = attachHostMessageListener({
 });
 
 window.addEventListener('beforeunload', () => {
+  // Best-effort: dispose() cancels a scheduled apply, which would drop the
+  // last debounce window of typing on tab close. Post it first.
+  syncController.flushApply(serializeMarkdownForHost);
   detachHostMessageListener();
   syncController.dispose();
   mermaidPreview.dispose();

--- a/tests/e2e/save-integrity.e2e.mjs
+++ b/tests/e2e/save-integrity.e2e.mjs
@@ -1,0 +1,74 @@
+import { expect, browser } from '@wdio/globals';
+import {
+  openWorkspaceFile,
+  waitForCustomEditor,
+  waitForCustomEditorWebviewReady,
+  waitForWorkspaceFileText,
+  withCustomEditorWebview,
+} from './helpers.mjs';
+
+const typeInProseMirror = async (keys) => {
+  await withCustomEditorWebview(async () => {
+    const editor = await browser.$('.ProseMirror');
+    await editor.waitForDisplayed({ timeout: 5_000 });
+    await editor.click();
+    await browser.keys(['End']);
+    await browser.keys(keys);
+  });
+};
+
+const readDiskText = async (fileName) =>
+  browser.executeWorkbench(async (vscode, relativeFileName) => {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    if (!workspaceFolder) {
+      throw new Error('No workspace folder available in VS Code test session.');
+    }
+    const uri = vscode.Uri.joinPath(workspaceFolder.uri, relativeFileName);
+    const bytes = await vscode.workspace.fs.readFile(uri);
+    return new TextDecoder().decode(bytes);
+  }, fileName);
+
+describe('Save integrity', () => {
+  it('keeps syncing keystrokes after a no-op apply and persists them on save', async () => {
+    await openWorkspaceFile('save-pipeline.md');
+    await waitForCustomEditor('save-pipeline.md');
+    await waitForCustomEditorWebviewReady();
+
+    await typeInProseMirror('zulu');
+    await waitForWorkspaceFileText(
+      'save-pipeline.md',
+      (text) => text.includes('zulu'),
+      'Expected typed text to reach the host document.',
+      { attempts: 25, interval: 200 },
+    );
+
+    // Char + immediate backspace serializes to unchanged markdown -> the host
+    // treats the apply as a no-op. Typing afterwards must still sync.
+    await typeInProseMirror(['x', 'Backspace']);
+    await typeInProseMirror('yankee');
+    await waitForWorkspaceFileText(
+      'save-pipeline.md',
+      (text) => text.includes('yankee'),
+      'Expected keystrokes after a no-op apply to keep reaching the host document.',
+      { attempts: 25, interval: 200 },
+    );
+
+    await browser.executeWorkbench(async (vscode) => {
+      await vscode.commands.executeCommand('workbench.action.files.save');
+    });
+
+    await browser.waitUntil(
+      async () => {
+        const diskText = await readDiskText('save-pipeline.md');
+        return diskText.includes('zulu') && diskText.includes('yankee');
+      },
+      {
+        timeout: 10_000,
+        timeoutMsg: 'Expected saved file on disk to contain all typed text.',
+      },
+    );
+
+    const finalDiskText = await readDiskText('save-pipeline.md');
+    expect(finalDiskText).toContain('Alpha bravo charlie delta.');
+  });
+});

--- a/tests/fixtures/save-pipeline-autosave.md
+++ b/tests/fixtures/save-pipeline-autosave.md
@@ -1,0 +1,3 @@
+# Autosave Pipeline
+
+Echo foxtrot golf hotel.

--- a/tests/fixtures/save-pipeline.md
+++ b/tests/fixtures/save-pipeline.md
@@ -1,0 +1,3 @@
+# Save Pipeline
+
+Alpha bravo charlie delta.

--- a/tests/helpers/vscode.js
+++ b/tests/helpers/vscode.js
@@ -1,4 +1,5 @@
 const fs = require('fs').promises;
+const path = require('path');
 
 class Uri {
   constructor(value, scheme, fsPath) {
@@ -15,6 +16,10 @@ class Uri {
     const [scheme, rest = ''] = value.split(':');
     const fsPath = rest.startsWith('/') ? rest : `/${rest}`;
     return new Uri(value, scheme, fsPath);
+  }
+
+  static joinPath(base, ...segments) {
+    return Uri.file(path.posix.join(base.fsPath, ...segments));
   }
 
   toString() {

--- a/tests/integration-cli/core-workflow.test.ts
+++ b/tests/integration-cli/core-workflow.test.ts
@@ -212,7 +212,7 @@ describe('Integration CLI: core workflow', () => {
       const document = await vscode.workspace.openTextDocument(uri);
       const sync = new DocumentSync(document);
       const result = await sync.applyDocument(testCase.serialized, 0);
-      expect(result, testCase.name).to.deep.equal({ ok: true });
+      expect(result, testCase.name).to.deep.equal({ ok: true, applied: true });
 
       const saved = await document.save();
       expect(saved, testCase.name).to.equal(true);

--- a/tests/integration-cli/save-chain.test.ts
+++ b/tests/integration-cli/save-chain.test.ts
@@ -98,7 +98,11 @@ describe('Integration CLI: save chain', () => {
       expect(diskText).to.include('Echo foxtrot golf hotel.');
     } finally {
       await filesConfiguration.update('autoSave', 'off', vscode.ConfigurationTarget.Global);
-      await filesConfiguration.update('autoSaveDelay', undefined, vscode.ConfigurationTarget.Global);
+      await filesConfiguration.update(
+        'autoSaveDelay',
+        undefined,
+        vscode.ConfigurationTarget.Global,
+      );
     }
   });
 });

--- a/tests/integration-cli/save-chain.test.ts
+++ b/tests/integration-cli/save-chain.test.ts
@@ -1,0 +1,104 @@
+import * as vscode from 'vscode';
+
+let expect: Chai.ExpectStatic;
+
+before(async () => {
+  ({ expect } = await import('chai'));
+});
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+const waitFor = async (
+  predicate: () => boolean,
+  timeoutMs = 15_000,
+  intervalMs = 100,
+): Promise<void> => {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) {
+      return;
+    }
+    await sleep(intervalMs);
+  }
+  throw new Error('Timed out waiting for save chain condition.');
+};
+
+const getActiveCustomViewType = (): string | undefined => {
+  const tab = vscode.window.tabGroups.activeTabGroup.activeTab;
+  if (!tab) {
+    return undefined;
+  }
+  if (tab.input instanceof vscode.TabInputCustom) {
+    return tab.input.viewType;
+  }
+  return undefined;
+};
+
+const openInCustomEditor = async (fileName: string): Promise<vscode.TextDocument> => {
+  const extension = vscode.extensions.getExtension('blueclouddev.muninn-vscode');
+  expect(extension).to.not.equal(undefined);
+  await extension?.activate();
+
+  const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+  expect(workspaceFolder, 'expected integration workspace folder').to.not.equal(undefined);
+
+  const uri = vscode.Uri.joinPath(workspaceFolder!.uri, fileName);
+  const document = await vscode.workspace.openTextDocument(uri);
+  await vscode.commands.executeCommand('vscode.open', uri);
+  await waitFor(() => getActiveCustomViewType() === 'muninn.markdownEditor');
+  return document;
+};
+
+const insertMermaidUntilApplied = async (document: vscode.TextDocument): Promise<void> => {
+  let inserted = false;
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    await vscode.commands.executeCommand('muninn.insertMermaidBlock');
+    await sleep(250);
+    if (document.getText().includes('```mermaid')) {
+      inserted = true;
+      break;
+    }
+  }
+  expect(inserted, 'expected mermaid block to be inserted via webview round trip').to.equal(true);
+};
+
+const readDiskText = async (document: vscode.TextDocument): Promise<string> => {
+  const bytes = await vscode.workspace.fs.readFile(document.uri);
+  return new TextDecoder().decode(bytes);
+};
+
+describe('Integration CLI: save chain', () => {
+  it('marks the document dirty after a webview edit and persists it on save', async () => {
+    const document = await openInCustomEditor('save-pipeline.md');
+
+    await insertMermaidUntilApplied(document);
+    expect(document.isDirty, 'webview edit must dirty the TextDocument').to.equal(true);
+
+    await vscode.commands.executeCommand('workbench.action.files.save');
+    await waitFor(() => !document.isDirty);
+
+    const diskText = await readDiskText(document);
+    expect(diskText).to.include('```mermaid');
+    expect(diskText).to.include('Alpha bravo charlie delta.');
+  });
+
+  it('persists webview edits through autosave without an explicit save', async () => {
+    const filesConfiguration = vscode.workspace.getConfiguration('files');
+    await filesConfiguration.update('autoSave', 'afterDelay', vscode.ConfigurationTarget.Global);
+    await filesConfiguration.update('autoSaveDelay', 200, vscode.ConfigurationTarget.Global);
+
+    try {
+      const document = await openInCustomEditor('save-pipeline-autosave.md');
+
+      await insertMermaidUntilApplied(document);
+      await waitFor(() => !document.isDirty);
+
+      const diskText = await readDiskText(document);
+      expect(diskText).to.include('```mermaid');
+      expect(diskText).to.include('Echo foxtrot golf hotel.');
+    } finally {
+      await filesConfiguration.update('autoSave', 'off', vscode.ConfigurationTarget.Global);
+      await filesConfiguration.update('autoSaveDelay', undefined, vscode.ConfigurationTarget.Global);
+    }
+  });
+});

--- a/tests/unit/custom-editor-provider.test.ts
+++ b/tests/unit/custom-editor-provider.test.ts
@@ -1,0 +1,136 @@
+import * as vscode from 'vscode';
+import { MuninnCustomEditorProvider } from '../../src/custom-editor/muninn-custom-editor-provider';
+import type { HostToViewMessage } from '../../src/custom-editor/protocol';
+import type { ConfigService } from '../../src/services/config-service';
+import type { Logger } from '../../src/services/logger';
+
+let expect: Chai.ExpectStatic;
+
+before(async () => {
+  ({ expect } = await import('chai'));
+});
+
+type FakePanel = {
+  panel: vscode.WebviewPanel;
+  posted: HostToViewMessage[];
+  sendViewMessage: (message: unknown) => Promise<void>;
+};
+
+const createFakePanel = (): FakePanel => {
+  const posted: HostToViewMessage[] = [];
+  let messageListener: ((message: unknown) => Promise<void> | void) | undefined;
+
+  const panel = {
+    webview: {
+      options: {},
+      html: '',
+      cspSource: 'vscode-webview-resource:',
+      asWebviewUri: (uri: vscode.Uri) => uri,
+      onDidReceiveMessage: (listener: (message: unknown) => Promise<void> | void) => {
+        messageListener = listener;
+        return { dispose: () => {} };
+      },
+      postMessage: async (message: HostToViewMessage) => {
+        posted.push(message);
+        return true;
+      },
+    },
+    onDidDispose: () => ({ dispose: () => {} }),
+  } as unknown as vscode.WebviewPanel;
+
+  return {
+    panel,
+    posted,
+    sendViewMessage: async (message: unknown) => {
+      await messageListener?.(message);
+    },
+  };
+};
+
+const createMarkdownDocument = (text: string): vscode.TextDocument =>
+  ({
+    uri: vscode.Uri.file('/workspace/noop.md'),
+    getText: () => text,
+    lineCount: 1,
+    lineAt: () => ({
+      range: { end: new vscode.Position(0, text.length) },
+    }),
+  }) as unknown as vscode.TextDocument;
+
+describe('MuninnCustomEditorProvider view.applyDocument handling', () => {
+  const workspaceWithApplyEdit = vscode.workspace as unknown as {
+    applyEdit?: (edit: vscode.WorkspaceEdit) => Promise<boolean>;
+  };
+  const originalApplyEdit = workspaceWithApplyEdit.applyEdit;
+  let provider: MuninnCustomEditorProvider;
+
+  beforeEach(() => {
+    provider = new MuninnCustomEditorProvider(
+      vscode.Uri.file('/extension'),
+      {} as unknown as ConfigService,
+      { warn: () => {}, info: () => {}, error: () => {} } as unknown as Logger,
+    );
+  });
+
+  afterEach(() => {
+    provider.dispose();
+    workspaceWithApplyEdit.applyEdit = originalApplyEdit;
+  });
+
+  it('acknowledges a no-op apply with a documentChanged snapshot', async () => {
+    const { panel, posted, sendViewMessage } = createFakePanel();
+    await provider.resolveCustomTextEditor(createMarkdownDocument('# unchanged'), panel);
+
+    await sendViewMessage({
+      type: 'view.applyDocument',
+      payload: { markdown: '# unchanged', revision: 0 },
+    });
+
+    // Without this reply the webview's inFlightApply latch never releases and
+    // every subsequent edit is dropped (the autosave/data-loss deadlock).
+    expect(posted).to.deep.equal([
+      {
+        type: 'host.documentChanged',
+        payload: { markdown: '# unchanged', revision: 0 },
+      },
+    ]);
+  });
+
+  it('posts nothing extra when an edit is applied (the document event echoes instead)', async () => {
+    workspaceWithApplyEdit.applyEdit = async () => true;
+    const { panel, posted, sendViewMessage } = createFakePanel();
+    await provider.resolveCustomTextEditor(createMarkdownDocument('# before'), panel);
+
+    await sendViewMessage({
+      type: 'view.applyDocument',
+      payload: { markdown: '# after', revision: 0 },
+    });
+
+    expect(posted).to.deep.equal([]);
+  });
+
+  it('replies with host.error and a snapshot when the apply fails', async () => {
+    workspaceWithApplyEdit.applyEdit = async () => false;
+    const { panel, posted, sendViewMessage } = createFakePanel();
+    await provider.resolveCustomTextEditor(createMarkdownDocument('# before'), panel);
+
+    await sendViewMessage({
+      type: 'view.applyDocument',
+      payload: { markdown: '# after', revision: 0 },
+    });
+
+    expect(posted).to.deep.equal([
+      {
+        type: 'host.error',
+        payload: {
+          code: 'apply_failed',
+          message: 'VS Code failed to apply the markdown update.',
+        },
+      },
+      {
+        type: 'host.documentChanged',
+        payload: { markdown: '# before', revision: 0 },
+      },
+    ]);
+  });
+});

--- a/tests/unit/document-sync.test.ts
+++ b/tests/unit/document-sync.test.ts
@@ -95,7 +95,7 @@ describe('DocumentSync', () => {
     });
   });
 
-  it('skips workspace edits when markdown is unchanged', async () => {
+  it('skips workspace edits when markdown is unchanged and reports the no-op', async () => {
     const uri = vscode.Uri.file('/workspace/unchanged.md');
     const document = {
       uri,
@@ -108,7 +108,30 @@ describe('DocumentSync', () => {
 
     const sync = new DocumentSync(document);
     const result = await sync.applyDocument('# unchanged', 0);
-    expect(result).to.deep.equal({ ok: true });
+    expect(result).to.deep.equal({ ok: true, applied: false });
+  });
+
+  it('treats a serialization that only drops the final newline as a no-op', async () => {
+    const appliedEdits: InspectableWorkspaceEdit[] = [];
+    workspaceWithApplyEdit.applyEdit = async (edit: vscode.WorkspaceEdit) => {
+      appliedEdits.push(edit as InspectableWorkspaceEdit);
+      return true;
+    };
+
+    const uri = vscode.Uri.file('/workspace/newline-only.md');
+    const document = {
+      uri,
+      getText: () => '# unchanged\n',
+      lineCount: 2,
+      lineAt: (line: number) => ({
+        range: { end: new vscode.Position(line, line === 0 ? 11 : 0) },
+      }),
+    } as unknown as vscode.TextDocument;
+
+    const sync = new DocumentSync(document);
+    const result = await sync.applyDocument('# unchanged', 0);
+    expect(result).to.deep.equal({ ok: true, applied: false });
+    expect(appliedEdits.length).to.equal(0);
   });
 
   it('applies markdown edits and reports host failures', async () => {
@@ -130,7 +153,7 @@ describe('DocumentSync', () => {
 
     const sync = new DocumentSync(document);
     const success = await sync.applyDocument('# after', 0);
-    expect(success).to.deep.equal({ ok: true });
+    expect(success).to.deep.equal({ ok: true, applied: true });
     expect(appliedEdits.length).to.equal(1);
     expect(appliedEdits[0]?.replacements.length).to.equal(1);
     expect(appliedEdits[0]?.replacements[0]?.uri.toString()).to.equal(uri.toString());
@@ -168,7 +191,9 @@ describe('DocumentSync', () => {
         applied: '# after',
       },
       { name: 'empty document', current: '', serialized: '# after', applied: '# after' },
-      { name: 'single newline document', current: '\n', serialized: '', applied: '\n' },
+      // Reconciling '' against a current '\n' yields '\n' — identical to the
+      // document, so no edit must be applied at all.
+      { name: 'single newline document', current: '\n', serialized: '', applied: undefined },
     ];
 
     for (const testCase of cases) {
@@ -187,9 +212,16 @@ describe('DocumentSync', () => {
       const beforeCount = appliedEdits.length;
       const result = await sync.applyDocument(testCase.serialized, 0);
 
-      expect(result, testCase.name).to.deep.equal({ ok: true });
-      expect(appliedEdits.length, testCase.name).to.equal(beforeCount + 1);
-      expect(appliedEdits.at(-1)?.replacements[0]?.text, testCase.name).to.equal(testCase.applied);
+      if (testCase.applied === undefined) {
+        expect(result, testCase.name).to.deep.equal({ ok: true, applied: false });
+        expect(appliedEdits.length, testCase.name).to.equal(beforeCount);
+      } else {
+        expect(result, testCase.name).to.deep.equal({ ok: true, applied: true });
+        expect(appliedEdits.length, testCase.name).to.equal(beforeCount + 1);
+        expect(appliedEdits.at(-1)?.replacements[0]?.text, testCase.name).to.equal(
+          testCase.applied,
+        );
+      }
     }
   });
 });

--- a/tests/unit/protocol.test.ts
+++ b/tests/unit/protocol.test.ts
@@ -60,6 +60,12 @@ describe('custom editor protocol guards', () => {
     ).to.equal(true);
     expect(
       isHostToViewMessage({
+        type: 'host.documentChanged',
+        payload: { markdown: '# doc', revision: 2 },
+      }),
+    ).to.equal(true);
+    expect(
+      isHostToViewMessage({
         type: 'host.executeCommand',
         payload: { command: 'insertMermaidBlock' },
       }),
@@ -90,6 +96,18 @@ describe('custom editor protocol guards', () => {
       isHostToViewMessage({
         type: 'host.init',
         payload: { markdown: '', revision: 0, mermaidEnabled: true },
+      }),
+    ).to.equal(false);
+    expect(
+      isHostToViewMessage({
+        type: 'host.documentChanged',
+        payload: { markdown: '# doc' },
+      }),
+    ).to.equal(false);
+    expect(
+      isHostToViewMessage({
+        type: 'host.documentChanged',
+        payload: { markdown: 42, revision: 1 },
       }),
     ).to.equal(false);
     expect(

--- a/tests/unit/sync-controller.test.ts
+++ b/tests/unit/sync-controller.test.ts
@@ -1,0 +1,125 @@
+import sinon from 'sinon';
+import { HostSyncController, type ApplyDocumentPayload } from '../../src/webview/editor/sync';
+
+let expect: Chai.ExpectStatic;
+
+before(async () => {
+  ({ expect } = await import('chai'));
+});
+
+describe('HostSyncController', () => {
+  let clock: sinon.SinonFakeTimers;
+  let posted: ApplyDocumentPayload[];
+  let controller: HostSyncController;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+    posted = [];
+    controller = new HostSyncController({
+      debounceMs: 80,
+      postApply: (payload) => posted.push(payload),
+    });
+  });
+
+  afterEach(() => {
+    controller.dispose();
+    clock.restore();
+  });
+
+  it('coalesces rapid edits and serializes at flush time', () => {
+    // Production always passes the same serializeMarkdownForHost function; the
+    // debounce timer captures the FIRST closure, so the content that gets
+    // posted is whatever the document holds when the timer fires.
+    let markdown = 'draft one';
+    const getMarkdown = (): string => markdown;
+
+    controller.queueApply(getMarkdown);
+    markdown = 'draft two';
+    controller.queueApply(getMarkdown);
+    expect(posted.length).to.equal(0);
+
+    clock.tick(80);
+    expect(posted).to.deep.equal([{ markdown: 'draft two', revision: 0 }]);
+  });
+
+  it('holds further applies until the host replies, then retries pending edits', () => {
+    controller.queueApply(() => 'first');
+    clock.tick(80);
+    expect(posted.length).to.equal(1);
+
+    controller.queueApply(() => 'second');
+    clock.tick(10_000);
+    expect(posted.length).to.equal(1);
+
+    const shouldRetry = controller.handleHostDocumentChanged(1);
+    expect(shouldRetry).to.equal(true);
+
+    controller.queueApply(() => 'second');
+    clock.tick(80);
+    expect(posted.length).to.equal(2);
+    expect(posted[1]).to.deep.equal({ markdown: 'second', revision: 1 });
+  });
+
+  it('never posts again if the host stays silent after an apply', () => {
+    // Documents the contract the host MUST honor: every view.applyDocument
+    // needs a reply (host.documentChanged or host.error). Without one the
+    // latch below is permanent by design — see the no-op ack in the provider.
+    controller.queueApply(() => 'first');
+    clock.tick(80);
+    expect(posted.length).to.equal(1);
+
+    controller.queueApply(() => 'second');
+    controller.flushApply(() => 'second');
+    clock.tick(60_000);
+    expect(posted.length).to.equal(1);
+  });
+
+  it('flushApply posts pending content immediately and cancels the timer', () => {
+    controller.queueApply(() => 'pending');
+    controller.flushApply(() => 'pending');
+    expect(posted).to.deep.equal([{ markdown: 'pending', revision: 0 }]);
+
+    clock.tick(80);
+    expect(posted.length).to.equal(1);
+  });
+
+  it('flushApply does nothing when no edit is pending', () => {
+    controller.flushApply(() => 'never sent');
+    expect(posted.length).to.equal(0);
+  });
+
+  it('ignores edits queued while sync is suppressed', () => {
+    controller.withSuppressedSync(() => {
+      controller.queueApply(() => 'suppressed');
+    });
+    clock.tick(80);
+    expect(posted.length).to.equal(0);
+  });
+
+  it('handleHostError releases the latch and reports pending work', () => {
+    controller.queueApply(() => 'first');
+    clock.tick(80);
+    controller.queueApply(() => 'second');
+
+    const shouldRetry = controller.handleHostError();
+    expect(shouldRetry).to.equal(true);
+
+    controller.queueApply(() => 'second');
+    clock.tick(80);
+    expect(posted.length).to.equal(2);
+  });
+
+  it('dispose cancels a scheduled apply', () => {
+    controller.queueApply(() => 'pending');
+    controller.dispose();
+    clock.tick(80);
+    expect(posted.length).to.equal(0);
+  });
+
+  it('tracks the host revision in posted payloads', () => {
+    controller.setRevision(7);
+    controller.queueApply(() => 'revisioned');
+    clock.tick(80);
+    expect(posted).to.deep.equal([{ markdown: 'revisioned', revision: 7 }]);
+  });
+});


### PR DESCRIPTION
## Summary

- **Fixes a permanent sync deadlock that silently drops edits.** `HostSyncController` latches `inFlightApply` on every `view.applyDocument` and only releases it on a host reply — but `DocumentSync.applyDocument()` returns success *without* applying an edit when the markdown is unchanged, so no `onDidChangeTextDocument` echo ever fires and the latch never releases. From that point every keystroke is queued and never sent: the document never goes dirty, autosave has nothing to save, and closing the tab loses everything typed since (Ctrl+Z cannot recover content that never reached the `TextDocument`). The host now replies with a `host.documentChanged` snapshot whenever an apply needs no edit.
- **Unifies the no-op check with #294's newline reconcile.** Reconciling *before* the unchanged check catches the second silent no-op path: a serialization differing from the document only by the dropped final newline now reports `applied: false` instead of applying an identity `WorkspaceEdit`. `applyDocument` returns `{ ok, applied }` so the provider knows whether an echo will follow.
- **Flushes pending edits on webview teardown** instead of cancelling them (`beforeunload` previously dropped the last debounce window of typing on tab close; best-effort by platform design).
- **Backfills the missing test layers around the save pipeline:** unit coverage for the `HostSyncController` state machine (was zero tests and excluded from coverage — now nyc-enforced at ~95%), a provider regression test for the ack contract, `host.documentChanged` protocol guards, real-VS-Code integration tests for dirty→save→disk and the full autosave chain, and an e2e spec that types real keystrokes through a no-op round trip and verifies the bytes on disk.

Executed plan: `docs/superpowers/plans/2026-06-11-save-pipeline-noop-ack.md` (includes the post-#294 adaptation notes).

Out of scope (follow-up): `applyHostMarkdown` rebuilds the ProseMirror `EditorState` (fresh `history()` plugin) whenever host markdown differs from the webview serialization — wiping undo history and resetting the cursor. Since #294's reconcile makes every echo differ by the final newline, this now triggers on every successful flush and deserves its own fix (transaction-based host updates vs. gated rebuild).

## Test Plan
- [x] `npm run coverage` — 117 unit tests passing, thresholds met with `sync.js` newly enforced (95% lines / 89% branches)
- [x] `npm run test:integration` — 9 passing, including new dirty→save→disk and autosave chains against real VS Code
- [x] `npm run test:e2e` — all specs exit 0; new `save-integrity` spec green (keystrokes → no-op round trip → keystrokes → save → disk)
- [x] `npm run lint` / `npm run format:check` / `npm run typecheck` — clean
- [x] `npm run test:roundtrip` — report regenerates with no diff (no codec changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a deadlock in the custom markdown editor where edits could be silently dropped after document sync operations completed without changes.
  * Improved save pipeline reliability by ensuring all pending edits are properly flushed when closing the editor tab or window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->