### PR TITLE
docs: publish security posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Muninn provides a reading-first Markdown experience in VS Code with a custom edi
 - `muninn.integrations.mermaid.allowInUntrustedWorkspaces`
 - `muninn.toolbar.mode` (`basic` or `advanced`)
 
+## Security
+
+- [Security policy](SECURITY.md)
+- [Security posture](docs/SECURITY_POSTURE.md)
+
 ## Development
 
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,7 +30,7 @@ Please include as much of the following as you can:
 - Impact assessment, including what data or capability could be exposed or modified.
 - Proof-of-concept details, if available.
 
-You should receive an initial response within 72 hours. Confirmed vulnerabilities will be triaged privately, fixed on a branch or private fork when needed, and disclosed after a patched release or mitigation is available.
+Maintainers will respond as soon as practical. Confirmed vulnerabilities will be triaged privately, fixed on a branch or private fork when needed, and disclosed after a patched release or mitigation is available.
 
 ## Credit and Disclosure
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,24 +2,24 @@
 
 ## Supported Versions
 
-Muninn is currently pre-release software. Security fixes target the default branch and the latest published preview release.
+Muninn is currently pre-release software. Security fixes target the default branch. The repository currently has no GitHub release; once preview packages are published, security fixes will also target the latest published preview release.
 
-| Version                        | Supported |
-| ------------------------------ | --------- |
-| `main`                         | Yes       |
-| Latest published `2.x` preview | Yes       |
-| Older preview builds           | No        |
-| `1.x` and earlier              | No        |
+| Version                                | Supported |
+| -------------------------------------- | --------- |
+| `main`                                 | Yes       |
+| Latest published `2.x` preview, if any | Yes       |
+| Older preview builds                   | No        |
+| `1.x` and earlier                      | No        |
 
 ## Reporting a Vulnerability
 
 Please do not report security vulnerabilities through public GitHub issues, pull requests, discussions, or social channels.
 
-Use GitHub's private vulnerability reporting flow:
+Use GitHub's private vulnerability reporting flow when it is enabled for this repository:
 
 https://github.com/bluecloud-dev/muninn-vscode/security/advisories/new
 
-If private vulnerability reporting is unavailable, open a minimal public issue asking for a private security contact. Do not include exploit details, proof-of-concept code, affected files, or sensitive logs in that public issue.
+Maintainers must keep GitHub private vulnerability reporting enabled before relying on that link as the primary intake channel. If private vulnerability reporting is unavailable, open a minimal public issue asking for a private security contact. Do not include exploit details, proof-of-concept code, affected files, or sensitive logs in that public issue.
 
 Please include as much of the following as you can:
 
@@ -31,3 +31,9 @@ Please include as much of the following as you can:
 - Proof-of-concept details, if available.
 
 You should receive an initial response within 72 hours. Confirmed vulnerabilities will be triaged privately, fixed on a branch or private fork when needed, and disclosed after a patched release or mitigation is available.
+
+## Credit and Disclosure
+
+Muninn does not currently operate a paid bug bounty. Security reporters may request public credit in the eventual advisory or release notes; maintainers will honor that preference when disclosure is safe and coordinated.
+
+For implementation-level evidence, see [docs/SECURITY_POSTURE.md](docs/SECURITY_POSTURE.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Welcome to the **Muninn for VS Code** extension engineering documentation. This 
 | [DEVELOPMENT.md](DEVELOPMENT.md)                                               | Setup guide, development workflow, and debugging tips        | New Contributors         |
 | [TESTING.md](TESTING.md)                                                       | Test structure, running tests, and writing new tests         | Developers, QA           |
 | [RELEASE.md](RELEASE.md)                                                       | Release process checklist and versioning guidelines          | Maintainers              |
+| [SECURITY_POSTURE.md](SECURITY_POSTURE.md)                                     | Code-cited security posture and maintainer review checklist  | Maintainers, Security    |
 | [TROUBLESHOOTING.md](TROUBLESHOOTING.md)                                       | Common issues and solutions for developers                   | All                      |
 | [ROADMAP.md](ROADMAP.md)                                                       | Feature roadmap and milestone planning                       | All                      |
 | [BRAND_NAMING_CONTRACT.md](BRAND_NAMING_CONTRACT.md)                           | Canonical naming, IDs, and logo rules for the Muninn suite   | Maintainers, Product     |
@@ -30,6 +31,7 @@ Welcome to the **Muninn for VS Code** extension engineering documentation. This 
 - **Getting Started:** Begin with [GETTING_STARTED.md](GETTING_STARTED.md) for a guided first run
 - **Environment Setup:** Use [DEVELOPMENT.md](DEVELOPMENT.md) for day-to-day workflow
 - **Understanding the Code:** Read [ARCHITECTURE.md](ARCHITECTURE.md) for the big picture
+- **Security Posture:** Review [SECURITY_POSTURE.md](SECURITY_POSTURE.md) before publishing security claims
 - **Running Tests:** See [TESTING.md](TESTING.md) for test commands and structure
 - **Releasing:** Follow [RELEASE.md](RELEASE.md) when preparing a release
 

--- a/docs/SECURITY_POSTURE.md
+++ b/docs/SECURITY_POSTURE.md
@@ -1,0 +1,133 @@
+# Muninn Security Posture
+
+This document records the security posture that exists in the repository as of
+2026-06-14. It is an engineering evidence file, not a marketing badge: every
+claim below is tied to repository code or configuration and should be rechecked
+before publication or release.
+
+## Runtime Surface
+
+- Muninn is a VS Code extension with a TypeScript extension host entry point and
+  one sanctioned custom editor webview (`package.json:63-90`,
+  `package.json:92-107`, `src/extension.ts:1-9`,
+  `src/custom-editor/muninn-custom-editor-provider.ts:78-86`).
+- Runtime activation is limited to startup, the Muninn custom editor, and
+  declared Muninn commands (`package.json:63-83`).
+- The top-level runtime dependency surface is `markdown-it`,
+  `markdown-it-front-matter`, `mermaid`, and the ProseMirror packages listed in
+  `package.json:429-441`.
+- Development, test, packaging, and release dependencies are separated under
+  `devDependencies` (`package.json:443-473`).
+
+## Webview Isolation
+
+- The custom editor webview enables scripts because the ProseMirror editor runs
+  inside the webview, but local resources are restricted to the extension's
+  `media` directory (`src/custom-editor/muninn-custom-editor-provider.ts:82-85`).
+- The generated webview HTML sets a CSP with `default-src 'none'`, a scoped
+  image policy, extension-scoped styles, and nonce-only scripts
+  (`src/custom-editor/muninn-custom-editor-provider.ts:368-389`).
+- The webview bootstrap data is JSON-serialized and escapes `<` before it is
+  placed in the nonce-bearing setup script
+  (`src/custom-editor/muninn-custom-editor-provider.ts:29-30`,
+  `src/custom-editor/muninn-custom-editor-provider.ts:368-387`).
+
+## Host/Webview Message Boundary
+
+- Incoming webview messages are rejected unless they pass the
+  `isViewToHostMessage` type guard before dispatch
+  (`src/custom-editor/muninn-custom-editor-provider.ts:104-112`).
+- Accepted webview-to-host messages are limited to `view.ready`,
+  `view.applyDocument`, `view.executeCommand` for `openRawMarkdown`, and
+  `view.requestLinkInput` (`src/custom-editor/protocol.ts:60-79`,
+  `src/custom-editor/protocol.ts:122-147`).
+- Serialized document payloads require a string `markdown` value and a finite
+  numeric `revision` before they can cross the boundary
+  (`src/custom-editor/protocol.ts:81-100`).
+- Host-to-webview messages are also modeled as a closed union and validated by
+  `isHostToViewMessage` for callers that need a guard
+  (`src/custom-editor/protocol.ts:20-58`,
+  `src/custom-editor/protocol.ts:149-197`).
+
+## Markdown and Mermaid Handling
+
+- The Markdown parser is configured with `html: false`, so raw HTML is parsed as
+  document text rather than executable HTML
+  (`src/webview/editor/markdown-codec.ts:30-33`).
+- Mermaid rendering output is sanitized before insertion into the DOM in both
+  the preview panel and inline Mermaid preview
+  (`src/webview/editor/preview.ts:63-69`,
+  `src/webview/editor/nodes/table-node-view.ts:244-250`).
+- The Mermaid SVG sanitizer removes `script`, `iframe`, `object`, and `embed`
+  nodes; converts `foreignObject` labels to SVG text where possible; removes
+  inline event handler attributes; and removes `javascript:` or `data:text/html`
+  links from `href`/`xlink:href` (`src/webview/editor/preview.ts:125-160`).
+- Mermaid rendering is trust-aware. It is disabled in untrusted workspaces unless
+  users explicitly enable `muninn.integrations.mermaid.allowInUntrustedWorkspaces`
+  (`package.json:86-90`, `package.json:385-396`,
+  `src/services/config-service.ts:11-15`,
+  `src/integrations/mermaid-adapter.ts:4-20`).
+
+## Telemetry and Network Behavior
+
+- Muninn declares and enforces a no-telemetry policy with
+  `npm run check:no-telemetry` (`package.json:410-427`,
+  `scripts/check-no-telemetry.js:22-36`,
+  `.github/workflows/ci.yml:61-62`, `.github/workflows/release.yml:53-54`).
+- The no-telemetry check scans TypeScript files under `src/` for the token
+  `telemetry` and fails if it appears (`scripts/check-no-telemetry.js:4-36`).
+- As of the 2026-06-14 audit, runtime source under `src/` contains no direct
+  calls to `fetch`, `XMLHttpRequest`, `WebSocket`, `EventSource`, or `eval`. The
+  webview CSP permits `https:` image sources but no default network source
+  (`src/custom-editor/muninn-custom-editor-provider.ts:376-379`).
+
+## Supply Chain and CI
+
+- CI runs lint, formatting, typecheck, coverage, integration tests, and the
+  no-telemetry guard on pull requests to `main` (`.github/workflows/ci.yml:3-7`,
+  `.github/workflows/ci.yml:36-62`).
+- The security workflow runs CodeQL for JavaScript/TypeScript and GitHub Actions,
+  runs Dependency Review on pull requests, and runs OpenSSF Scorecard on
+  non-pull-request events with SARIF upload to the Security tab
+  (`.github/workflows/security.yml:20-54`,
+  `.github/workflows/security.yml:55-73`,
+  `.github/workflows/security.yml:74-100`).
+- Dependabot is configured for weekly npm and GitHub Actions updates
+  (`.github/dependabot.yml:1-40`).
+- Current GitHub Actions references use version tags such as
+  `actions/checkout@v6`, `github/codeql-action/init@v4`, and
+  `ossf/scorecard-action@v2.4.3`; they are not pinned by SHA in the current
+  workflows (`.github/workflows/ci.yml:24-31`,
+  `.github/workflows/security.yml:38-51`,
+  `.github/workflows/security.yml:90-99`,
+  `.github/workflows/release.yml:15-20`,
+  `.github/workflows/release.yml:96-100`).
+- No OpenSSF Scorecard badge is published here because this repository does not
+  yet commit a verified score. Add a badge only after a real score exists.
+
+## What Muninn Does Not Do
+
+- Muninn does not intentionally collect telemetry. This is enforced by
+  `scripts/check-no-telemetry.js` and CI (`scripts/check-no-telemetry.js:22-36`,
+  `.github/workflows/ci.yml:61-62`).
+- Muninn does not intentionally execute Markdown document content as HTML:
+  Markdown parsing uses `html: false`
+  (`src/webview/editor/markdown-codec.ts:30-33`).
+- Muninn does not intentionally execute Mermaid output without sanitization:
+  rendered SVG passes through `sanitizeMermaidSvg` before DOM insertion
+  (`src/webview/editor/preview.ts:63-69`,
+  `src/webview/editor/preview.ts:125-160`,
+  `src/webview/editor/nodes/table-node-view.ts:244-250`).
+- Muninn does not intentionally use `eval` or direct runtime network APIs in
+  `src/` as of the 2026-06-14 source audit.
+
+## Maintainer Review Checklist
+
+- [ ] Confirm GitHub private vulnerability reporting is enabled for
+      `bluecloud-dev/muninn-vscode`; the repository API response reviewed on
+      2026-06-14 did not expose it under `security_and_analysis`.
+- [ ] Re-run the no-runtime-network source search before release:
+      `rg -n "\\b(fetch|XMLHttpRequest|WebSocket|EventSource|eval\\()" src`.
+- [ ] Review whether GitHub Actions should be pinned by SHA in a dedicated
+      workflow-hardening issue. Do not claim SHA pinning until it is true.
+- [ ] Add an OpenSSF Scorecard badge only after a real published score exists.


### PR DESCRIPTION
## Summary
- Add `docs/SECURITY_POSTURE.md` with code-cited claims for webview CSP, message validation, Mermaid sanitization, workspace trust gating, no-telemetry enforcement, CI/security workflows, and dependency surface.
- Refresh `SECURITY.md` so the disclosure policy does not overclaim GitHub releases or private vulnerability reporting status.
- Link the security policy and posture doc from the root README and docs index.

## Audit Notes
- OpenSSF Scorecard already exists in `.github/workflows/security.yml`, so this PR does not add a duplicate workflow.
- Current workflow Actions use version tags, not SHA pins; the posture doc records that fact instead of claiming pinned Actions.
- No OpenSSF badge or score is added because no verified score is committed.
- Maintainer review still needed before merge: confirm GitHub private vulnerability reporting is enabled for `bluecloud-dev/muninn-vscode`.

## Verification
- `npm ci`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run check:no-telemetry`
- `npx prettier --check SECURITY.md docs/README.md docs/SECURITY_POSTURE.md`
- `actionlint .github/workflows/*.yml`

Fixes #267


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive security documentation with updated security policy clarifying pre-release status and vulnerability reporting procedures.
  * Added security posture documentation detailing runtime constraints, isolation practices, safeguards, and CI/supply-chain practices.
  * Updated vulnerability reporting guidance directing reporters to GitHub's private vulnerability flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->