### PR TITLE
Table grid semantics: column scope + accessible table names

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -20,6 +20,7 @@
   "Enter the link destination.": "Enter the link destination.",
   "Link URL is required.": "Link URL is required.",
   "Link URL cannot contain spaces.": "Link URL cannot contain spaces.",
+  "Table {0}: {1} columns, {2} rows": "Table {0}: {1} columns, {2} rows",
   "Recent": "Recent",
   "Insert Code Block": "Insert Code Block",
   "Select the code language": "Select the code language",

--- a/src/shared/webview-strings.ts
+++ b/src/shared/webview-strings.ts
@@ -74,6 +74,7 @@ export type WebviewStrings = {
   tableApplySourceButton: string;
   tableApplySourceTitle: string;
   tableSourceHint: string;
+  tableGridAriaLabelTemplate: string;
   tableHeaderColumnLabelTemplate: string;
   tableNewColumnHeaderTemplate: string;
   tableRowColumnLabelTemplate: string;
@@ -166,6 +167,7 @@ export const DEFAULT_WEBVIEW_STRINGS: WebviewStrings = {
   tableApplySourceButton: 'Apply Source',
   tableApplySourceTitle: 'Apply source (Ctrl/Cmd+Enter)',
   tableSourceHint: 'Edit Markdown table source. Press Ctrl/Cmd+Enter to apply changes.',
+  tableGridAriaLabelTemplate: 'Table {0}: {1} columns, {2} rows',
   tableHeaderColumnLabelTemplate: 'Header column {0}',
   tableNewColumnHeaderTemplate: 'Column {0}',
   tableRowColumnLabelTemplate: 'Row {0} column {1}',

--- a/src/webview/editor/nodes/table-node-view.ts
+++ b/src/webview/editor/nodes/table-node-view.ts
@@ -78,6 +78,38 @@ const buildReplacementNode = (
 ): ProseMirrorNode =>
   schema.nodes.code_block.create(attributes, source.length > 0 ? [schema.text(source)] : undefined);
 
+export const getTableGridAriaLabel = (tableIndex: number, table: MarkdownTable): string =>
+  formatString(
+    getString('tableGridAriaLabelTemplate'),
+    tableIndex,
+    table.headers.length,
+    table.rows.length,
+  );
+
+export const getTableNodeDocumentIndex = (
+  documentNode: ProseMirrorNode,
+  tablePosition: number,
+): number => {
+  let tableIndex = 0;
+  let matchedIndex: number | undefined;
+
+  documentNode.descendants((node, position) => {
+    if (!isTableCodeBlockNode(node)) {
+      return true;
+    }
+
+    tableIndex += 1;
+    if (position !== tablePosition) {
+      return true;
+    }
+
+    matchedIndex = tableIndex;
+    return false;
+  });
+
+  return matchedIndex ?? 1;
+};
+
 class GenericCodeBlockNodeView implements NodeView {
   readonly dom: HTMLDivElement;
   readonly contentDOM: HTMLElement;
@@ -447,11 +479,16 @@ class TableCodeBlockNodeView implements NodeView {
   private renderGrid(table: MarkdownTable): void {
     const tableElement = document.createElement('table');
     tableElement.className = 'muninn-table-node-grid-table';
+    tableElement.setAttribute(
+      'aria-label',
+      getTableGridAriaLabel(this.getCurrentTableDocumentIndex(), table),
+    );
 
     const head = document.createElement('thead');
     const headRow = document.createElement('tr');
     for (const [columnIndex, value] of table.headers.entries()) {
       const th = document.createElement('th');
+      th.setAttribute('scope', 'col');
       th.append(this.createCellInput(value, -1, columnIndex));
       headRow.append(th);
     }
@@ -607,7 +644,16 @@ class TableCodeBlockNodeView implements NodeView {
     return true;
   }
 
-  private resolveNodePosition(): number | undefined {
+  private getCurrentTableDocumentIndex(): number {
+    const position = this.resolveCurrentNodePosition();
+    if (position === undefined) {
+      return 1;
+    }
+
+    return getTableNodeDocumentIndex(this.view.state.doc, position);
+  }
+
+  private resolveCurrentNodePosition(): number | undefined {
     try {
       const position = this.getPos();
       if (typeof position === 'number') {
@@ -615,6 +661,24 @@ class TableCodeBlockNodeView implements NodeView {
       }
     } catch {
       // Fallback below handles transient node-view position races.
+    }
+
+    let matchedPosition: number | undefined;
+    this.view.state.doc.descendants((node, position) => {
+      if (!isTableCodeBlockNode(node) || !node.eq(this.node)) {
+        return true;
+      }
+
+      matchedPosition = position;
+      return false;
+    });
+    return matchedPosition;
+  }
+
+  private resolveNodePosition(): number | undefined {
+    const currentPosition = this.resolveCurrentNodePosition();
+    if (currentPosition !== undefined) {
+      return currentPosition;
     }
 
     let matchedPosition: number | undefined;

--- a/tests/e2e/table.e2e.mjs
+++ b/tests/e2e/table.e2e.mjs
@@ -14,6 +14,24 @@ const waitForSampleMarkdown = (predicate, errorMessage) =>
 const executeCommandAndWaitForSampleMarkdown = (command, predicate, errorMessage) =>
   executeWorkbenchCommandAndWaitForWorkspaceFileText('sample.md', command, predicate, errorMessage);
 
+const expectTableGridSemantics = async ({ columnCount, rowCount, tableIndex = 1 }) => {
+  await withCustomEditorWebview(async () => {
+    const tableNode = await browser.$('[data-testid="muninn-table-node"]');
+    const gridTable = await tableNode.$('.muninn-table-node-grid-table');
+    await gridTable.waitForDisplayed({ timeout: 5_000 });
+    await expect(gridTable).toHaveAttribute(
+      'aria-label',
+      `Table ${tableIndex}: ${columnCount} columns, ${rowCount} rows`,
+    );
+
+    const headerCells = await gridTable.$$('th');
+    expect(headerCells.length).toBe(columnCount);
+    for (const headerCell of headerCells) {
+      await expect(headerCell).toHaveAttribute('scope', 'col');
+    }
+  });
+};
+
 const isTableInPreviewMode = async () => {
   let previewVisible = false;
   await withCustomEditorWebview(async () => {
@@ -52,7 +70,8 @@ const applyTableSourceFromWebview = async (source, mode) => {
       await applySourceButton.waitForEnabled({ timeout: 5_000 });
       await applySourceButton.click();
     } else {
-      const applyShortcut = process.platform === 'darwin' ? ['Meta', 'Enter'] : ['Control', 'Enter'];
+      const applyShortcut =
+        process.platform === 'darwin' ? ['Meta', 'Enter'] : ['Control', 'Enter'];
       await browser.keys(applyShortcut);
     }
   });
@@ -97,6 +116,7 @@ describe('Table node view workflow', () => {
       await expect(deleteButton).toHaveAttribute('aria-label', 'Delete table');
       await expect(deleteButton).toHaveElementClass('muninn-button-danger');
     });
+    await expectTableGridSemantics({ columnCount: 2, rowCount: 1 });
 
     await executeCommandAndWaitForSampleMarkdown(
       'muninn.addTableColumn',
@@ -109,6 +129,7 @@ describe('Table node view workflow', () => {
       (text) => /\|\s*\|\s*\|\s*\|/.test(text),
       'Expected add-table-row command to persist in markdown.',
     );
+    await expectTableGridSemantics({ columnCount: 3, rowCount: 2 });
 
     const text = await readWorkspaceFileText('sample.md');
     expect(text).not.toContain('```muninn-table');
@@ -133,6 +154,7 @@ describe('Table node view workflow', () => {
       (text) => text.includes('| Name | Score |') && text.includes('| Alice | 7 |'),
       'Expected Apply Source button path to persist edited markdown table source.',
     );
+    await expectTableGridSemantics({ columnCount: 2, rowCount: 1 });
 
     await applyTableSourceFromWebview(
       ['| Name | Score |', '| --- | --- |', '| Ben | 9 |'].join('\n'),
@@ -144,5 +166,6 @@ describe('Table node view workflow', () => {
       'Expected Ctrl/Cmd+Enter source-apply path to persist edited markdown table source.',
     );
     expect(text).not.toContain('```muninn-table');
+    await expectTableGridSemantics({ columnCount: 2, rowCount: 1 });
   });
 });

--- a/tests/unit/table-node-view.test.ts
+++ b/tests/unit/table-node-view.test.ts
@@ -1,0 +1,61 @@
+import { DEFAULT_WEBVIEW_STRINGS } from '../../src/shared/webview-strings';
+import { schema } from '../../src/webview/editor/markdown-codec';
+import {
+  DEFAULT_TABLE_SOURCE,
+  getTableGridAriaLabel,
+  getTableNodeDocumentIndex,
+  TABLE_FENCE_LANGUAGE,
+  type MarkdownTable,
+} from '../../src/webview/editor/nodes/table-node-view';
+
+let expect: Chai.ExpectStatic;
+
+before(async () => {
+  ({ expect } = await import('chai'));
+});
+
+const createTableNode = () =>
+  schema.nodes.code_block.create(
+    { params: TABLE_FENCE_LANGUAGE },
+    schema.text(DEFAULT_TABLE_SOURCE),
+  );
+
+describe('table node view accessibility helpers', () => {
+  it('formats localized grid names from the parsed table model', () => {
+    const table: MarkdownTable = {
+      headers: ['Name', 'Score', 'Notes'],
+      rows: [
+        ['Alice', '7', ''],
+        ['Ben', '9', ''],
+      ],
+    };
+
+    expect(DEFAULT_WEBVIEW_STRINGS.tableGridAriaLabelTemplate).to.equal(
+      'Table {0}: {1} columns, {2} rows',
+    );
+    expect(getTableGridAriaLabel(2, table)).to.equal('Table 2: 3 columns, 2 rows');
+  });
+
+  it('counts only editable table nodes when deriving document-order table names', () => {
+    const firstTable = createTableNode();
+    const secondTable = createTableNode();
+    const documentNode = schema.nodes.doc.create(undefined, [
+      firstTable,
+      schema.nodes.code_block.create({ params: 'typescript' }, schema.text('const value = 1;')),
+      schema.nodes.paragraph.create(undefined, schema.text('Between tables')),
+      secondTable,
+    ]);
+
+    const tablePositions: number[] = [];
+    documentNode.descendants((node, position) => {
+      if (node.type.name === 'code_block' && node.attrs.params === TABLE_FENCE_LANGUAGE) {
+        tablePositions.push(position);
+      }
+      return true;
+    });
+
+    expect(tablePositions).to.have.length(2);
+    expect(getTableNodeDocumentIndex(documentNode, tablePositions[0])).to.equal(1);
+    expect(getTableNodeDocumentIndex(documentNode, tablePositions[1])).to.equal(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Added `scope="col"` to editable table grid header cells.
- Added localized grid table names using `Table {0}: {1} columns, {2} rows`, with the table index derived from ProseMirror document order at render time.
- Added focused unit coverage for table label/index helpers and E2E DOM assertions for initial render, add-row/add-column, and source-apply paths.

## Verification

- `npm ci` — passed
- `npm run format:check` — passed
- `npm run lint` — passed
- `npm run typecheck` — passed
- `npm run check:no-telemetry` — passed
- `npm run coverage` — passed, 106 tests passing; coverage thresholds met
- `npm run compile` — passed
- `npm run bundle` — passed
- `xvfb-run -a npm run test:e2e -- --spec tests/e2e/table.e2e.mjs` — passed, 2 table workflow tests passing

## E2E Notes

The targeted Linux table E2E run passed. WDIO reported the spec as passed with `1 retries`; there was no app assertion failure, and the new DOM assertions for `aria-label` and `scope="col"` passed.

Fixes #248
