### PR TITLE
fix(a11y): add roving toolbar focus

### DIFF
--- a/src/webview/editor/bootstrap.ts
+++ b/src/webview/editor/bootstrap.ts
@@ -27,27 +27,27 @@ export const bootstrapEditorApp = (): EditorBootstrap => {
   <div class="muninn-toolbar" role="toolbar" aria-label="${getHtmlString('toolbarAriaLabel')}">
     <div class="muninn-toolbar-group" data-group="text" role="group" aria-labelledby="muninn-toolbar-group-text-label">
       <span id="muninn-toolbar-group-text-label" class="muninn-toolbar-group-label">${getHtmlString('toolbarGroupTextLabel')}</span>
-      <button type="button" data-command="toggleBold" aria-pressed="false" title="${getHtmlString('toolbarButtonBoldTitle')}">${getHtmlString('commandLabelBold')}</button>
-      <button type="button" data-command="toggleItalic" aria-pressed="false" title="${getHtmlString('toolbarButtonItalicTitle')}">${getHtmlString('commandLabelItalic')}</button>
-      <button type="button" data-command="insertLink" aria-pressed="false" title="${getHtmlString('toolbarButtonLinkTitle')}">${getHtmlString('commandLabelLink')}</button>
+      <button type="button" data-command="toggleBold" aria-pressed="false" tabindex="0" title="${getHtmlString('toolbarButtonBoldTitle')}">${getHtmlString('commandLabelBold')}</button>
+      <button type="button" data-command="toggleItalic" aria-pressed="false" tabindex="-1" title="${getHtmlString('toolbarButtonItalicTitle')}">${getHtmlString('commandLabelItalic')}</button>
+      <button type="button" data-command="insertLink" aria-pressed="false" tabindex="-1" title="${getHtmlString('toolbarButtonLinkTitle')}">${getHtmlString('commandLabelLink')}</button>
     </div>
     <div class="muninn-toolbar-group" data-group="structure" role="group" aria-labelledby="muninn-toolbar-group-structure-label">
       <span id="muninn-toolbar-group-structure-label" class="muninn-toolbar-group-label">${getHtmlString('toolbarGroupStructureLabel')}</span>
-      <button type="button" data-command="setHeading1" aria-pressed="false" title="${getHtmlString('toolbarButtonHeading1Title')}">${getHtmlString('toolbarButtonHeading1Label')}</button>
-      <button type="button" data-command="setHeading2" aria-pressed="false" title="${getHtmlString('toolbarButtonHeading2Title')}">${getHtmlString('toolbarButtonHeading2Label')}</button>
-      <button type="button" data-command="setHeading3" aria-pressed="false" data-advanced="true" title="${getHtmlString('toolbarButtonHeading3Title')}">${getHtmlString('toolbarButtonHeading3Label')}</button>
-      <button type="button" data-command="setParagraph" aria-pressed="false" title="${getHtmlString('toolbarButtonParagraphTitle')}">${getHtmlString('commandLabelParagraph')}</button>
-      <button type="button" data-command="toggleBulletList" aria-pressed="false" data-advanced="true" title="${getHtmlString('toolbarButtonBulletTitle')}">${getHtmlString('toolbarButtonBulletLabel')}</button>
-      <button type="button" data-command="toggleNumberedList" aria-pressed="false" data-advanced="true" title="${getHtmlString('toolbarButtonNumberedTitle')}">${getHtmlString('toolbarButtonNumberedLabel')}</button>
+      <button type="button" data-command="setHeading1" aria-pressed="false" tabindex="-1" title="${getHtmlString('toolbarButtonHeading1Title')}">${getHtmlString('toolbarButtonHeading1Label')}</button>
+      <button type="button" data-command="setHeading2" aria-pressed="false" tabindex="-1" title="${getHtmlString('toolbarButtonHeading2Title')}">${getHtmlString('toolbarButtonHeading2Label')}</button>
+      <button type="button" id="muninn-toolbar-heading-3" data-command="setHeading3" aria-pressed="false" data-advanced="true" tabindex="-1" hidden title="${getHtmlString('toolbarButtonHeading3Title')}">${getHtmlString('toolbarButtonHeading3Label')}</button>
+      <button type="button" data-command="setParagraph" aria-pressed="false" tabindex="-1" title="${getHtmlString('toolbarButtonParagraphTitle')}">${getHtmlString('commandLabelParagraph')}</button>
+      <button type="button" id="muninn-toolbar-bullet-list" data-command="toggleBulletList" aria-pressed="false" data-advanced="true" tabindex="-1" hidden title="${getHtmlString('toolbarButtonBulletTitle')}">${getHtmlString('toolbarButtonBulletLabel')}</button>
+      <button type="button" id="muninn-toolbar-numbered-list" data-command="toggleNumberedList" aria-pressed="false" data-advanced="true" tabindex="-1" hidden title="${getHtmlString('toolbarButtonNumberedTitle')}">${getHtmlString('toolbarButtonNumberedLabel')}</button>
     </div>
     <div class="muninn-toolbar-group" data-group="insert" role="group" aria-labelledby="muninn-toolbar-group-insert-label">
       <span id="muninn-toolbar-group-insert-label" class="muninn-toolbar-group-label">${getHtmlString('toolbarGroupInsertLabel')}</span>
-      <button type="button" data-command="insertTable" title="${getHtmlString('toolbarButtonTableTitle')}">${getHtmlString('commandLabelTable')}</button>
-      <button type="button" data-command="insertCodeBlock" title="${getHtmlString('toolbarButtonCodeTitle')}">${getHtmlString('commandLabelCodeBlock')}</button>
-      <button type="button" data-command="insertMermaidBlock" data-advanced="true" title="${getHtmlString('toolbarButtonMermaidTitle')}">${getHtmlString('toolbarButtonMermaidLabel')}</button>
-      <button type="button" data-command="openRawMarkdown" title="${getHtmlString('toolbarButtonSourceTitle')}">${getHtmlString('toolbarButtonSourceLabel')}</button>
+      <button type="button" data-command="insertTable" tabindex="-1" title="${getHtmlString('toolbarButtonTableTitle')}">${getHtmlString('commandLabelTable')}</button>
+      <button type="button" data-command="insertCodeBlock" tabindex="-1" title="${getHtmlString('toolbarButtonCodeTitle')}">${getHtmlString('commandLabelCodeBlock')}</button>
+      <button type="button" id="muninn-toolbar-mermaid" data-command="insertMermaidBlock" data-advanced="true" tabindex="-1" hidden title="${getHtmlString('toolbarButtonMermaidTitle')}">${getHtmlString('toolbarButtonMermaidLabel')}</button>
+      <button type="button" data-command="openRawMarkdown" tabindex="-1" title="${getHtmlString('toolbarButtonSourceTitle')}">${getHtmlString('toolbarButtonSourceLabel')}</button>
     </div>
-    <button type="button" class="muninn-toolbar-more" data-testid="muninn-toolbar-more" aria-expanded="false" title="${getHtmlString('toolbarMoreTitle')}">${getHtmlString('toolbarMoreLabel')}</button>
+    <button type="button" class="muninn-toolbar-more" data-testid="muninn-toolbar-more" aria-controls="muninn-toolbar-heading-3 muninn-toolbar-bullet-list muninn-toolbar-numbered-list muninn-toolbar-mermaid" aria-expanded="false" tabindex="-1" title="${getHtmlString('toolbarMoreTitle')}">${getHtmlString('toolbarMoreLabel')}</button>
   </div>
   <div class="muninn-editor-shell" id="editor-shell">
     <section id="mermaid-preview-panel" class="muninn-mermaid-preview-panel" aria-label="${getHtmlString('mermaidPreviewAriaLabel')}" hidden>

--- a/src/webview/editor/index.ts
+++ b/src/webview/editor/index.ts
@@ -27,6 +27,7 @@ import {
   serializeMarkdownTable,
   TABLE_FENCE_LANGUAGE,
 } from './tables/markdown-table-utilities';
+import { attachToolbarRovingFocus } from './toolbar-roving-focus';
 
 declare function acquireVsCodeApi(): {
   postMessage: (message: ViewToHostMessage) => void;
@@ -92,9 +93,16 @@ const formatCommandFailure = (command: string): string => {
   return formatString(getString('commandFailureGenericTemplate'), label);
 };
 
-const { editorContainer, statusLine, mermaidPreviewPanel, mermaidPreviewBody, toolbarButtons } =
-  bootstrapEditorApp();
+const {
+  editorContainer,
+  toolbar,
+  statusLine,
+  mermaidPreviewPanel,
+  mermaidPreviewBody,
+  toolbarButtons,
+} = bootstrapEditorApp();
 const moreButton = document.querySelector<HTMLButtonElement>('[data-testid="muninn-toolbar-more"]');
+const toolbarRovingFocus = attachToolbarRovingFocus(toolbar);
 
 let view: EditorView | undefined;
 let toolbarMode: ToolbarMode = 'basic';
@@ -119,6 +127,8 @@ const updateAdvancedToolbarVisibility = (): void => {
     moreButton.hidden = toolbarMode === 'advanced';
     moreButton.setAttribute('aria-expanded', advancedActionsVisible ? 'true' : 'false');
   }
+
+  toolbarRovingFocus.revalidateCurrentStop(moreButton ?? undefined);
 };
 
 const getFirstAdvancedToolbarButton = (): HTMLButtonElement | undefined => {

--- a/src/webview/editor/toolbar-roving-focus.ts
+++ b/src/webview/editor/toolbar-roving-focus.ts
@@ -1,0 +1,95 @@
+export type ToolbarRovingFocusController = {
+  revalidateCurrentStop: (preferredFallback?: HTMLButtonElement) => void;
+};
+
+const NAVIGATION_KEYS = new Set(['ArrowLeft', 'ArrowRight', 'Home', 'End']);
+
+const isVisibleButton = (button: HTMLButtonElement): boolean => !button.hidden;
+
+const resolveFallback = (
+  visibleButtons: HTMLButtonElement[],
+  preferredFallback?: HTMLButtonElement,
+): HTMLButtonElement | undefined => {
+  if (preferredFallback && visibleButtons.includes(preferredFallback)) {
+    return preferredFallback;
+  }
+  return visibleButtons[0];
+};
+
+export const attachToolbarRovingFocus = (toolbar: HTMLElement): ToolbarRovingFocusController => {
+  const getButtons = (): HTMLButtonElement[] => [...toolbar.querySelectorAll('button')];
+  const getVisibleButtons = (): HTMLButtonElement[] =>
+    getButtons().filter((button) => isVisibleButton(button));
+  let currentStop: HTMLButtonElement | undefined = getVisibleButtons().find(
+    (button) => button.tabIndex === 0,
+  );
+
+  const setCurrentStop = (button: HTMLButtonElement | undefined, shouldFocus = false): void => {
+    for (const toolbarButton of getButtons()) {
+      toolbarButton.tabIndex = toolbarButton === button ? 0 : -1;
+    }
+
+    currentStop = button;
+    if (button && shouldFocus) {
+      button.focus();
+    }
+  };
+
+  const revalidateCurrentStop = (preferredFallback?: HTMLButtonElement): void => {
+    const visibleButtons = getVisibleButtons();
+    if (currentStop && visibleButtons.includes(currentStop)) {
+      setCurrentStop(currentStop);
+      return;
+    }
+    setCurrentStop(resolveFallback(visibleButtons, preferredFallback));
+  };
+
+  const moveFocus = (target: HTMLButtonElement, key: string): void => {
+    const visibleButtons = getVisibleButtons();
+    if (visibleButtons.length === 0) {
+      return;
+    }
+
+    if (key === 'Home') {
+      setCurrentStop(visibleButtons[0], true);
+      return;
+    }
+
+    if (key === 'End') {
+      setCurrentStop(visibleButtons.at(-1), true);
+      return;
+    }
+
+    const targetIndex = visibleButtons.includes(target)
+      ? visibleButtons.indexOf(target)
+      : Math.max(visibleButtons.indexOf(currentStop ?? visibleButtons[0]), 0);
+    const offset = key === 'ArrowRight' ? 1 : -1;
+    const nextIndex = (targetIndex + offset + visibleButtons.length) % visibleButtons.length;
+    setCurrentStop(visibleButtons[nextIndex], true);
+  };
+
+  toolbar.addEventListener('focusin', (event) => {
+    const target = event.target as HTMLButtonElement | null;
+    if (!target || !toolbar.contains(target) || !getButtons().includes(target) || target.hidden) {
+      return;
+    }
+    setCurrentStop(target);
+  });
+
+  toolbar.addEventListener('keydown', (event) => {
+    if (!NAVIGATION_KEYS.has(event.key)) {
+      return;
+    }
+
+    const target = event.target as HTMLButtonElement | null;
+    if (!target || !toolbar.contains(target) || !getButtons().includes(target)) {
+      return;
+    }
+
+    event.preventDefault();
+    moveFocus(target, event.key);
+  });
+
+  revalidateCurrentStop();
+  return { revalidateCurrentStop };
+};

--- a/tests/e2e/accessibility-toolbar.e2e.mjs
+++ b/tests/e2e/accessibility-toolbar.e2e.mjs
@@ -47,6 +47,23 @@ describe('Toolbar accessibility workflow', () => {
       await expect(moreButton).toHaveText('More');
       await expect(moreButton).toHaveAttribute('aria-expanded', 'false');
 
+      const controlledAdvancedButtons = await browser.execute(() => {
+        const more = document.querySelector('[data-testid="muninn-toolbar-more"]');
+        const ids = more?.getAttribute('aria-controls')?.trim().split(/\s+/).filter(Boolean) ?? [];
+        return ids.map((id) => {
+          const controlledElement = document.getElementById(id);
+          return {
+            advanced: controlledElement?.getAttribute('data-advanced') ?? null,
+            exists: Boolean(controlledElement),
+            id,
+          };
+        });
+      });
+      expect(controlledAdvancedButtons).toHaveLength(4);
+      expect(
+        controlledAdvancedButtons.every((entry) => entry.exists && entry.advanced === 'true'),
+      ).toBe(true);
+
       await moreButton.click();
 
       await expect(heading3Button).toBeDisplayed();
@@ -61,6 +78,81 @@ describe('Toolbar accessibility workflow', () => {
         {
           timeout: 2_000,
           timeoutMsg: 'Expected More to move focus to the first revealed advanced action.',
+        },
+      );
+    });
+  });
+
+  it('uses one toolbar tab stop and arrow navigation exits cleanly to the editor', async () => {
+    await openWorkspaceFile('with-formatting.md');
+    await waitForCustomEditor('with-formatting.md');
+
+    await withCustomEditorWebview(async () => {
+      await browser.execute(() => {
+        document.body.tabIndex = -1;
+        document.body.focus();
+      });
+
+      await browser.keys('Tab');
+      await browser.waitUntil(
+        async () => {
+          const activeCommand = await browser.execute(() =>
+            document.activeElement?.getAttribute('data-command'),
+          );
+          return activeCommand === 'toggleBold';
+        },
+        {
+          timeout: 2_000,
+          timeoutMsg: 'Expected one Tab to land on the first toolbar action.',
+        },
+      );
+
+      let tabStops = await browser.execute(() =>
+        [...document.querySelectorAll('.muninn-toolbar button')]
+          .filter((button) => !button.hidden && button.getAttribute('tabindex') === '0')
+          .map(
+            (button) =>
+              button.getAttribute('data-command') ?? button.getAttribute('data-testid') ?? '',
+          ),
+      );
+      expect(tabStops).toEqual(['toggleBold']);
+
+      for (let index = 0; index < 8; index += 1) {
+        await browser.keys('ArrowRight');
+      }
+      await browser.waitUntil(
+        async () => {
+          const activeCommand = await browser.execute(() =>
+            document.activeElement?.getAttribute('data-command'),
+          );
+          return activeCommand === 'openRawMarkdown';
+        },
+        {
+          timeout: 2_000,
+          timeoutMsg: 'Expected ArrowRight navigation to reach the Source button.',
+        },
+      );
+
+      tabStops = await browser.execute(() =>
+        [...document.querySelectorAll('.muninn-toolbar button')]
+          .filter((button) => !button.hidden && button.getAttribute('tabindex') === '0')
+          .map(
+            (button) =>
+              button.getAttribute('data-command') ?? button.getAttribute('data-testid') ?? '',
+          ),
+      );
+      expect(tabStops).toEqual(['openRawMarkdown']);
+
+      await browser.keys('Tab');
+      await browser.waitUntil(
+        async () =>
+          browser.execute(() => {
+            const editor = document.querySelector('.ProseMirror');
+            return Boolean(editor && document.activeElement === editor);
+          }),
+        {
+          timeout: 2_000,
+          timeoutMsg: 'Expected Tab from the toolbar roving stop to exit to the editor.',
         },
       );
     });

--- a/tests/unit/toolbar-roving-focus.test.ts
+++ b/tests/unit/toolbar-roving-focus.test.ts
@@ -1,0 +1,143 @@
+import { attachToolbarRovingFocus } from '../../src/webview/editor/toolbar-roving-focus';
+
+let expect: Chai.ExpectStatic;
+
+before(async () => {
+  ({ expect } = await import('chai'));
+});
+
+type RecordedKeyboardEvent = {
+  defaultPrevented: boolean;
+  key: string;
+  preventDefault: () => void;
+  target: FakeButton;
+};
+
+class FakeButton {
+  public hidden = false;
+  public tabIndex = -1;
+  public readonly focusedKeys: string[] = [];
+
+  public constructor(public readonly command: string) {}
+
+  public focus(): void {
+    this.focusedKeys.push(this.command);
+  }
+}
+
+class FakeToolbar {
+  private readonly listeners = new Map<string, EventListener[]>();
+
+  public constructor(private readonly buttons: FakeButton[]) {}
+
+  public addEventListener(type: string, listener: EventListener): void {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  public contains(target: EventTarget | null): boolean {
+    return this.buttons.includes(target as unknown as FakeButton);
+  }
+
+  public querySelectorAll(selector: string): NodeListOf<HTMLButtonElement> {
+    expect(selector).to.equal('button');
+    return this.buttons as unknown as NodeListOf<HTMLButtonElement>;
+  }
+
+  public dispatchFocusIn(target: FakeButton): void {
+    for (const listener of this.listeners.get('focusin') ?? []) {
+      listener({ target } as unknown as FocusEvent);
+    }
+  }
+
+  public dispatchKeydown(target: FakeButton, key: string): RecordedKeyboardEvent {
+    const event: RecordedKeyboardEvent = {
+      defaultPrevented: false,
+      key,
+      preventDefault(): void {
+        event.defaultPrevented = true;
+      },
+      target,
+    };
+
+    for (const listener of this.listeners.get('keydown') ?? []) {
+      listener(event as unknown as KeyboardEvent);
+    }
+
+    return event;
+  }
+}
+
+describe('toolbar roving focus', () => {
+  it('wraps arrow-key focus across visible toolbar buttons', () => {
+    const bold = new FakeButton('toggleBold');
+    const italic = new FakeButton('toggleItalic');
+    const source = new FakeButton('openRawMarkdown');
+    const toolbar = new FakeToolbar([bold, italic, source]);
+
+    attachToolbarRovingFocus(toolbar as unknown as HTMLElement);
+
+    expect(bold.tabIndex).to.equal(0);
+    expect(italic.tabIndex).to.equal(-1);
+    expect(source.tabIndex).to.equal(-1);
+
+    const leftEvent = toolbar.dispatchKeydown(bold, 'ArrowLeft');
+    expect(leftEvent.defaultPrevented).to.equal(true);
+    expect(source.focusedKeys).to.deep.equal(['openRawMarkdown']);
+    expect(source.tabIndex).to.equal(0);
+    expect(bold.tabIndex).to.equal(-1);
+
+    const rightEvent = toolbar.dispatchKeydown(source, 'ArrowRight');
+    expect(rightEvent.defaultPrevented).to.equal(true);
+    expect(bold.focusedKeys).to.deep.equal(['toggleBold']);
+    expect(bold.tabIndex).to.equal(0);
+    expect(source.tabIndex).to.equal(-1);
+  });
+
+  it('skips hidden toolbar buttons for arrow and boundary keys', () => {
+    const bold = new FakeButton('toggleBold');
+    const hiddenHeading = new FakeButton('setHeading3');
+    const paragraph = new FakeButton('setParagraph');
+    const more = new FakeButton('more');
+    hiddenHeading.hidden = true;
+    const toolbar = new FakeToolbar([bold, hiddenHeading, paragraph, more]);
+
+    attachToolbarRovingFocus(toolbar as unknown as HTMLElement);
+
+    toolbar.dispatchKeydown(bold, 'ArrowRight');
+    expect(paragraph.focusedKeys).to.deep.equal(['setParagraph']);
+    expect(paragraph.tabIndex).to.equal(0);
+    expect(hiddenHeading.tabIndex).to.equal(-1);
+
+    toolbar.dispatchKeydown(paragraph, 'End');
+    expect(more.focusedKeys).to.deep.equal(['more']);
+    expect(more.tabIndex).to.equal(0);
+
+    toolbar.dispatchKeydown(more, 'Home');
+    expect(bold.focusedKeys).to.deep.equal(['toggleBold']);
+    expect(bold.tabIndex).to.equal(0);
+  });
+
+  it('revalidates a hidden roving stop to the preferred visible fallback', () => {
+    const bold = new FakeButton('toggleBold');
+    const hiddenHeading = new FakeButton('setHeading3');
+    const more = new FakeButton('more');
+    const toolbar = new FakeToolbar([bold, hiddenHeading, more]);
+    const rovingFocus = attachToolbarRovingFocus(toolbar as unknown as HTMLElement);
+
+    toolbar.dispatchFocusIn(hiddenHeading);
+    expect(hiddenHeading.tabIndex).to.equal(0);
+    expect(bold.tabIndex).to.equal(-1);
+
+    hiddenHeading.hidden = true;
+    rovingFocus.revalidateCurrentStop(more as unknown as HTMLButtonElement);
+    expect(more.tabIndex).to.equal(0);
+    expect(hiddenHeading.tabIndex).to.equal(-1);
+
+    more.hidden = true;
+    rovingFocus.revalidateCurrentStop(more as unknown as HTMLButtonElement);
+    expect(bold.tabIndex).to.equal(0);
+    expect(more.tabIndex).to.equal(-1);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a dependency-free toolbar roving-focus controller so the webview toolbar is one tab stop, with ArrowLeft/ArrowRight/Home/End moving across visible buttons.
- Revalidates the roving stop when advanced toolbar actions are hidden, preferring the More button before falling back to the first visible action.
- Adds stable IDs for advanced actions, `aria-controls` on More, unit coverage, and WDIO proof for tab/arrow/exit behavior.

## Verification

- `npm ci`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run check:no-telemetry`
- `npm run coverage`
- `npm run compile`
- `npm run bundle`
- `xvfb-run -a npm run test:e2e -- --spec tests/e2e/accessibility-toolbar.e2e.mjs`
- `xvfb-run -a npm test`

Known residual risk: the targeted E2E proof depends on the local VS Code/webview runner, but it passed after rebuilding the webview bundle.

Fixes #246


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keyboard navigation for the editor toolbar: use arrow keys to move between buttons and Tab to enter/exit the toolbar.
  * Advanced formatting commands (heading level 3, bullet list, numbered list, and diagram insertion) now organized in a collapsible More menu.

* **Accessibility Improvements**
  * Enhanced keyboard focus management and ARIA attributes for improved screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->