### PR TITLE
fix(table): preserve keyboard focus while editing cells

### DIFF
--- a/src/webview/editor/nodes/table-node-view.ts
+++ b/src/webview/editor/nodes/table-node-view.ts
@@ -50,6 +50,34 @@ type TableNodeViewOptions = {
   setStatus: (message: string) => void;
 };
 
+type TableCellCoordinates = {
+  row: number;
+  col: number;
+};
+
+type TableCellTextSelection = Pick<HTMLInputElement, 'selectionEnd' | 'selectionStart' | 'value'>;
+
+export const shouldNavigateTableCellHorizontally = (
+  input: TableCellTextSelection,
+  key: string,
+): boolean => {
+  const selectionStart = input.selectionStart;
+  const selectionEnd = input.selectionEnd;
+  if (typeof selectionStart !== 'number' || typeof selectionEnd !== 'number') {
+    return false;
+  }
+  if (selectionStart !== selectionEnd) {
+    return false;
+  }
+  if (key === 'ArrowLeft') {
+    return selectionStart === 0;
+  }
+  if (key === 'ArrowRight') {
+    return selectionStart === input.value.length;
+  }
+  return false;
+};
+
 const createSourceShortcutHintId = (): string => {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return `muninn-table-source-hint-${crypto.randomUUID()}`;
@@ -328,6 +356,7 @@ class TableCodeBlockNodeView implements NodeView {
   private sourceDraft = '';
   private sourceDirty = false;
   private normalizedCurrentSource = '';
+  private pendingFocus: TableCellCoordinates | undefined;
 
   constructor(
     private node: ProseMirrorNode,
@@ -441,6 +470,7 @@ class TableCodeBlockNodeView implements NodeView {
     if (!isTableCodeBlockNode(node)) {
       return false;
     }
+    this.pendingFocus ??= this.getFocusedCellCoordinates();
     this.node = node;
     this.normalizedCurrentSource = normalizeTableSource(this.node.textContent);
     this.render();
@@ -508,12 +538,16 @@ class TableCodeBlockNodeView implements NodeView {
     tableElement.append(body);
 
     this.gridContainer.replaceChildren(tableElement);
+    this.restorePendingFocus(table);
   }
 
   private createCellInput(value: string, rowIndex: number, columnIndex: number): HTMLInputElement {
     const input = document.createElement('input');
+    const logicalRowIndex = this.toLogicalRowIndex(rowIndex);
     input.type = 'text';
     input.className = 'muninn-table-node-cell';
+    input.dataset.tableRow = String(logicalRowIndex);
+    input.dataset.tableColumn = String(columnIndex);
     input.setAttribute(
       'aria-label',
       rowIndex < 0
@@ -521,33 +555,90 @@ class TableCodeBlockNodeView implements NodeView {
         : formatString(getString('tableRowColumnLabelTemplate'), rowIndex + 1, columnIndex + 1),
     );
     input.value = value;
+    input.addEventListener('focus', () => {
+      if (this.pendingFocus?.row === logicalRowIndex && this.pendingFocus.col === columnIndex) {
+        this.pendingFocus = undefined;
+      }
+    });
     input.addEventListener('change', () => {
+      this.pendingFocus ??= this.getFocusedCellCoordinates();
       this.updateCell(rowIndex, columnIndex, input.value);
     });
     input.addEventListener('keydown', (event) => {
-      if (event.key !== 'Enter') {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        const table = parseMarkdownTable(this.node.textContent);
+        const target = this.getVerticalTargetCell(table, logicalRowIndex, columnIndex, {
+          direction: event.shiftKey ? -1 : 1,
+        });
+        this.commitCellAndFocus(input, rowIndex, columnIndex, target);
         return;
       }
-      event.preventDefault();
-      input.blur();
+
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        input.value = value;
+        input.focus();
+        return;
+      }
+
+      if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+        event.preventDefault();
+        const table = parseMarkdownTable(this.node.textContent);
+        const target = this.getVerticalTargetCell(table, logicalRowIndex, columnIndex, {
+          direction: event.key === 'ArrowUp' ? -1 : 1,
+        });
+        this.moveFocusToCell(target);
+        return;
+      }
+
+      if (
+        (event.key === 'ArrowLeft' || event.key === 'ArrowRight') &&
+        shouldNavigateTableCellHorizontally(input, event.key)
+      ) {
+        event.preventDefault();
+        const table = parseMarkdownTable(this.node.textContent);
+        const target = this.getHorizontalTargetCell(table, logicalRowIndex, columnIndex, {
+          direction: event.key === 'ArrowLeft' ? -1 : 1,
+        });
+        this.moveFocusToCell(target);
+        return;
+      }
+
+      if (event.key === 'Tab') {
+        this.pendingFocus = this.getTabTargetCell(
+          parseMarkdownTable(this.node.textContent),
+          logicalRowIndex,
+          columnIndex,
+          event.shiftKey,
+        );
+      }
     });
     return input;
   }
 
-  private updateCell(rowIndex: number, columnIndex: number, value: string): void {
+  private updateCell(rowIndex: number, columnIndex: number, value: string): boolean {
     const table = parseMarkdownTable(this.node.textContent);
     if (rowIndex < 0) {
+      if (table.headers[columnIndex] === value) {
+        return false;
+      }
       table.headers[columnIndex] = value;
     } else {
       if (!table.rows[rowIndex]) {
-        return;
+        return false;
+      }
+      if (table.rows[rowIndex][columnIndex] === value) {
+        return false;
       }
       table.rows[rowIndex][columnIndex] = value;
     }
     this.applyTable(table, getString('statusTableUpdated'));
+    return true;
   }
 
   private addRow(): void {
+    this.pendingFocus ??= this.getFocusedCellCoordinates();
     const table = parseMarkdownTable(this.node.textContent);
     const columnCount = Math.max(2, table.headers.length);
     table.rows.push(Array.from({ length: columnCount }, () => ''));
@@ -555,6 +646,7 @@ class TableCodeBlockNodeView implements NodeView {
   }
 
   private addColumn(): void {
+    this.pendingFocus ??= this.getFocusedCellCoordinates();
     const table = parseMarkdownTable(this.node.textContent);
     const nextColumn = table.headers.length + 1;
     table.headers.push(formatString(getString('tableNewColumnHeaderTemplate'), nextColumn));
@@ -604,6 +696,7 @@ class TableCodeBlockNodeView implements NodeView {
   private applySourceFromTextarea(): void {
     const normalized = normalizeTableSource(this.sourceDraft);
     if (normalized !== this.normalizedCurrentSource) {
+      this.pendingFocus = { row: 0, col: 0 };
       const applied = this.applySource(normalized, getString('statusTableSourceApplied'));
       if (!applied) {
         this.setSourceFeedback('error', getString('statusTableSourceApplyFailed'));
@@ -621,6 +714,137 @@ class TableCodeBlockNodeView implements NodeView {
 
   private applyTable(table: MarkdownTable, statusMessage: string): void {
     this.applySource(serializeMarkdownTable(table), statusMessage);
+  }
+
+  private commitCellAndFocus(
+    input: HTMLInputElement,
+    rowIndex: number,
+    columnIndex: number,
+    target: TableCellCoordinates,
+  ): void {
+    this.pendingFocus = target;
+    if (this.updateCell(rowIndex, columnIndex, input.value)) {
+      return;
+    }
+
+    this.pendingFocus = undefined;
+    this.focusCell(target);
+  }
+
+  private moveFocusToCell(target: TableCellCoordinates): void {
+    this.pendingFocus = target;
+    this.focusCell(target);
+    if (this.pendingFocus?.row === target.row && this.pendingFocus.col === target.col) {
+      this.pendingFocus = undefined;
+    }
+  }
+
+  private toLogicalRowIndex(rowIndex: number): number {
+    return rowIndex + 1;
+  }
+
+  private getVerticalTargetCell(
+    table: MarkdownTable,
+    row: number,
+    col: number,
+    { direction }: { direction: -1 | 1 },
+  ): TableCellCoordinates {
+    return this.coerceCellCoordinates(table, { row: row + direction, col });
+  }
+
+  private getHorizontalTargetCell(
+    table: MarkdownTable,
+    row: number,
+    col: number,
+    { direction }: { direction: -1 | 1 },
+  ): TableCellCoordinates {
+    return this.coerceCellCoordinates(table, { row, col: col + direction });
+  }
+
+  private getTabTargetCell(
+    table: MarkdownTable,
+    row: number,
+    col: number,
+    shiftKey: boolean,
+  ): TableCellCoordinates | undefined {
+    const columnCount = table.headers.length;
+    const totalRows = table.rows.length + 1;
+    const linearIndex = row * columnCount + col + (shiftKey ? -1 : 1);
+    if (linearIndex < 0 || linearIndex >= totalRows * columnCount) {
+      return undefined;
+    }
+
+    return {
+      row: Math.floor(linearIndex / columnCount),
+      col: linearIndex % columnCount,
+    };
+  }
+
+  private coerceCellCoordinates(
+    table: MarkdownTable,
+    coordinates: TableCellCoordinates,
+  ): TableCellCoordinates {
+    return {
+      row: Math.min(Math.max(coordinates.row, 0), table.rows.length),
+      col: Math.min(Math.max(coordinates.col, 0), Math.max(table.headers.length - 1, 0)),
+    };
+  }
+
+  private getFocusedCellCoordinates(): TableCellCoordinates | undefined {
+    const activeElement = document.activeElement;
+    if (
+      !(activeElement instanceof HTMLInputElement) ||
+      !this.gridContainer.contains(activeElement)
+    ) {
+      return undefined;
+    }
+
+    return this.readCellCoordinates(activeElement);
+  }
+
+  private readCellCoordinates(input: HTMLInputElement): TableCellCoordinates | undefined {
+    const row = Number(input.dataset.tableRow);
+    const col = Number(input.dataset.tableColumn);
+    if (!Number.isInteger(row) || !Number.isInteger(col)) {
+      return undefined;
+    }
+    return { row, col };
+  }
+
+  private restorePendingFocus(table: MarkdownTable): void {
+    const target = this.pendingFocus;
+    if (!target) {
+      return;
+    }
+
+    this.pendingFocus = undefined;
+    this.focusCell(this.coerceCellCoordinates(table, target));
+  }
+
+  private focusCell(target: TableCellCoordinates): boolean {
+    const input = this.gridContainer.querySelector<HTMLInputElement>(
+      `.muninn-table-node-cell[data-table-row="${target.row}"][data-table-column="${target.col}"]`,
+    );
+    if (!input) {
+      return false;
+    }
+
+    const focusInput = (): void => {
+      input.focus();
+      input.select();
+    };
+
+    focusInput();
+    setTimeout(() => {
+      const activeElement = document.activeElement;
+      if (
+        activeElement !== input &&
+        (activeElement === document.body || !this.gridContainer.contains(activeElement))
+      ) {
+        focusInput();
+      }
+    }, 0);
+    return true;
   }
 
   private applySource(source: string, statusMessage: string): boolean {

--- a/src/webview/editor/nodes/table-node-view.ts
+++ b/src/webview/editor/nodes/table-node-view.ts
@@ -57,6 +57,10 @@ type TableCellCoordinates = {
 
 type TableCellTextSelection = Pick<HTMLInputElement, 'selectionEnd' | 'selectionStart' | 'value'>;
 
+export const shouldDeferTableCellKeyboardNavigation = (
+  event: Pick<KeyboardEvent, 'isComposing'>,
+): boolean => event.isComposing;
+
 export const shouldNavigateTableCellHorizontally = (
   input: TableCellTextSelection,
   key: string,
@@ -565,6 +569,10 @@ class TableCodeBlockNodeView implements NodeView {
       this.updateCell(rowIndex, columnIndex, input.value);
     });
     input.addEventListener('keydown', (event) => {
+      if (shouldDeferTableCellKeyboardNavigation(event)) {
+        return;
+      }
+
       if (event.key === 'Enter') {
         event.preventDefault();
         const table = parseMarkdownTable(this.node.textContent);

--- a/tests/e2e/table.e2e.mjs
+++ b/tests/e2e/table.e2e.mjs
@@ -14,6 +14,23 @@ const waitForSampleMarkdown = (predicate, errorMessage) =>
 const executeCommandAndWaitForSampleMarkdown = (command, predicate, errorMessage) =>
   executeWorkbenchCommandAndWaitForWorkspaceFileText('sample.md', command, predicate, errorMessage);
 
+const readActiveTableCellState = async () =>
+  browser.execute(() => {
+    const activeElement = document.activeElement;
+    return {
+      isBody: activeElement === document.body,
+      row:
+        activeElement instanceof HTMLInputElement
+          ? activeElement.dataset.tableRow ?? null
+          : null,
+      col:
+        activeElement instanceof HTMLInputElement
+          ? activeElement.dataset.tableColumn ?? null
+          : null,
+      value: activeElement instanceof HTMLInputElement ? activeElement.value : null,
+    };
+  });
+
 const expectTableGridSemantics = async ({ columnCount, rowCount, tableIndex = 1 }) => {
   await withCustomEditorWebview(async () => {
     const tableNode = await browser.$('[data-testid="muninn-table-node"]');
@@ -167,5 +184,76 @@ describe('Table node view workflow', () => {
     );
     expect(text).not.toContain('```muninn-table');
     await expectTableGridSemantics({ columnCount: 2, rowCount: 1 });
+  });
+
+  it('commits cells with Enter and keeps focus in the grid for Escape', async () => {
+    await openWorkspaceFile('sample.md');
+    await waitForCustomEditor('sample.md');
+
+    await executeCommandAndWaitForSampleMarkdown(
+      'muninn.insertTable',
+      (text) => text.includes('| Column 1 | Column 2 |'),
+      'Expected table insertion command to persist before keyboard checks.',
+    );
+    await executeCommandAndWaitForSampleMarkdown(
+      'muninn.addTableRow',
+      (text) => /\|\s*\|\s*\|\s*\|/.test(text),
+      'Expected second table row before keyboard checks.',
+    );
+
+    await withCustomEditorWebview(async () => {
+      const tableNode = await browser.$('[data-testid="muninn-table-node"]');
+      const firstBodyCell = await tableNode.$(
+        '.muninn-table-node-cell[data-table-row="1"][data-table-column="0"]',
+      );
+      await firstBodyCell.waitForDisplayed({ timeout: 5_000 });
+      await firstBodyCell.setValue('Alice');
+      await browser.keys('Enter');
+
+      await browser.waitUntil(
+        async () => {
+          const activeState = await readActiveTableCellState();
+          return (
+            !activeState.isBody &&
+            activeState.row === '2' &&
+            activeState.col === '0' &&
+            activeState.value === ''
+          );
+        },
+        {
+          timeout: 5_000,
+          timeoutMsg: 'Expected Enter to focus the same column in the next table row.',
+        },
+      );
+
+      const refreshedTableNode = await browser.$('[data-testid="muninn-table-node"]');
+      const secondBodyCell = await refreshedTableNode.$(
+        '.muninn-table-node-cell[data-table-row="2"][data-table-column="0"]',
+      );
+      await secondBodyCell.setValue('Draft');
+      await browser.keys('Escape');
+
+      await browser.waitUntil(
+        async () => {
+          const activeState = await readActiveTableCellState();
+          return (
+            !activeState.isBody &&
+            activeState.row === '2' &&
+            activeState.col === '0' &&
+            activeState.value === ''
+          );
+        },
+        {
+          timeout: 5_000,
+          timeoutMsg: 'Expected Escape to restore the committed value and keep cell focus.',
+        },
+      );
+    });
+
+    const text = await waitForSampleMarkdown(
+      (nextText) => nextText.includes('| Alice |'),
+      'Expected Enter to commit the edited table cell.',
+    );
+    expect(text).not.toContain('Draft');
   });
 });

--- a/tests/unit/table-node-view.test.ts
+++ b/tests/unit/table-node-view.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_TABLE_SOURCE,
   getTableGridAriaLabel,
   getTableNodeDocumentIndex,
+  shouldDeferTableCellKeyboardNavigation,
   shouldNavigateTableCellHorizontally,
   TABLE_FENCE_LANGUAGE,
   type MarkdownTable,
@@ -73,6 +74,11 @@ describe('table node view accessibility helpers', () => {
 });
 
 describe('table cell keyboard helpers', () => {
+  it('lets IME composition keystrokes stay native', () => {
+    expect(shouldDeferTableCellKeyboardNavigation({ isComposing: true })).to.equal(true);
+    expect(shouldDeferTableCellKeyboardNavigation({ isComposing: false })).to.equal(false);
+  });
+
   it('moves left or right only at collapsed text boundaries', () => {
     expect(
       shouldNavigateTableCellHorizontally(createInputState('Score', 0, 0), 'ArrowLeft'),

--- a/tests/unit/table-node-view.test.ts
+++ b/tests/unit/table-node-view.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_TABLE_SOURCE,
   getTableGridAriaLabel,
   getTableNodeDocumentIndex,
+  shouldNavigateTableCellHorizontally,
   TABLE_FENCE_LANGUAGE,
   type MarkdownTable,
 } from '../../src/webview/editor/nodes/table-node-view';
@@ -19,6 +20,17 @@ const createTableNode = () =>
     { params: TABLE_FENCE_LANGUAGE },
     schema.text(DEFAULT_TABLE_SOURCE),
   );
+
+const createInputState = (
+  value: string,
+  selectionStart: number,
+  selectionEnd: number,
+): HTMLInputElement =>
+  ({
+    value,
+    selectionStart,
+    selectionEnd,
+  }) as HTMLInputElement;
 
 describe('table node view accessibility helpers', () => {
   it('formats localized grid names from the parsed table model', () => {
@@ -57,5 +69,29 @@ describe('table node view accessibility helpers', () => {
     expect(tablePositions).to.have.length(2);
     expect(getTableNodeDocumentIndex(documentNode, tablePositions[0])).to.equal(1);
     expect(getTableNodeDocumentIndex(documentNode, tablePositions[1])).to.equal(2);
+  });
+});
+
+describe('table cell keyboard helpers', () => {
+  it('moves left or right only at collapsed text boundaries', () => {
+    expect(
+      shouldNavigateTableCellHorizontally(createInputState('Score', 0, 0), 'ArrowLeft'),
+    ).to.equal(true);
+    expect(
+      shouldNavigateTableCellHorizontally(createInputState('Score', 5, 5), 'ArrowRight'),
+    ).to.equal(true);
+
+    expect(
+      shouldNavigateTableCellHorizontally(createInputState('Score', 1, 1), 'ArrowLeft'),
+    ).to.equal(false);
+    expect(
+      shouldNavigateTableCellHorizontally(createInputState('Score', 4, 4), 'ArrowRight'),
+    ).to.equal(false);
+    expect(
+      shouldNavigateTableCellHorizontally(createInputState('Score', 0, 5), 'ArrowLeft'),
+    ).to.equal(false);
+    expect(shouldNavigateTableCellHorizontally(createInputState('Score', 0, 0), 'Home')).to.equal(
+      false,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Adds table-cell focus coordinates across table re-renders so committed edits re-focus the logical target cell instead of falling through to the document body.
- Implements spreadsheet-style Enter/Shift+Enter, Escape, and arrow-key navigation while preserving native Tab traversal.
- Covers the Left/Right caret-boundary predicate in unit tests and adds E2E coverage for Enter commit/focus and Escape revert/focus.

## Verification
- `npm ci`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run check:no-telemetry`
- `npm run coverage`
- `npm run compile`
- `npm run bundle`
- `node --check tests/e2e/table.e2e.mjs`
- `xvfb-run -a npm run test:e2e -- --spec tests/e2e/table.e2e.mjs --mochaOpts.grep "commits cells"`
- `xvfb-run -a npm run test:e2e -- --spec tests/e2e/table.e2e.mjs --mochaOpts.grep "applies source panel"`

Known residual risk: full `tests/e2e/table.e2e.mjs` still hit the existing VS Code/webview runner lifecycle failure locally (`target window already closed` / `web view not found`) after retries; the focused new keyboard test and the source-panel regression test pass when run directly.

Fixes #249


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved keyboard navigation within table cells, including precise left/right movement at caret boundaries.
  * Enter commits the current cell and moves focus to the next cell; Shift+Enter moves upward.
  * Escape now reliably reverts changes and restores focus to the same cell position.
  * Tab navigates to the next/previous cell in reading order.
* **Bug Fixes**
  * More consistent focus stability when editing, inserting rows/columns, or switching from source input back to the grid.
* **Tests**
  * Added unit and end-to-end coverage for table cell navigation and focus restoration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->