### PR TITLE
docs: add AGPL plain-language FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Muninn provides a reading-first Markdown experience in VS Code with a custom edi
 - Custom markdown editor (`muninn.markdownEditor`) opens by default.
 - Single-pane rich editing toolbar with grouped Text/Structure/Insert actions.
 - Mermaid block insertion with inline preview panel and guarded rendering.
-- In-editor table node view with editable grid, add-row/add-column, and source toggle.
-- Raw markdown escape hatch command.
+- In-editor tables with editable grid controls, source toggle, and keyboard-friendly cell navigation.
+- Source button and command for opening raw Markdown in VS Code.
 - Workspace trust-aware Mermaid gating.
 - No telemetry.
 
@@ -73,4 +73,12 @@ npm run package
 
 GNU Affero General Public License v3.0 (AGPL-3.0-only). See [LICENSE](LICENSE).
 
-Muninn is free software: you can use, study, share, and improve it. If you distribute a modified version — including serving it to users through a network-hosted VS Code environment (code-server, Codespaces, Gitpod, and similar) — you must make your modified source available under the same license.
+### License — plain language
+
+Using Muninn to edit files imposes nothing on those files, your employer's code, or any repository you open.
+Your markdown, and anything you write with Muninn, is yours.
+The AGPL governs copying, distributing, or modifying Muninn itself.
+If you distribute a modified Muninn, share it under the same license and keep required notices.
+If you serve a modified Muninn through hosted VS Code environments such as code-server, Codespaces, or Gitpod, offer users the source for that modified Muninn.
+Redistributing unmodified Muninn keeps the [LICENSE](LICENSE) and notices with the extension.
+Common-understanding summary, not legal advice; the [LICENSE](LICENSE) text governs.


### PR DESCRIPTION

## Summary
- Adds a short README "License — plain language" FAQ under License for #266.
- Clarifies that files edited with Muninn remain user-owned, and AGPL obligations concern Muninn itself.
- Lightly updates two Highlights bullets to match the current table and Source UI.

## Verification
- `npm ci`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run check:no-telemetry`
- `npm run package`
- README FAQ line-count/text probe: 7 nonblank FAQ lines, required phrases present
- README local link probe: existing local README links resolve in the repo
- Packaged README probe: `vsce` rewrote README links/images to GitHub URLs, and the VSIX contains `extension/readme.md` plus `extension/LICENSE.txt`

## Notes
- `THIRD_PARTY_NOTICES.md` is not present on current `origin/main`; #264 owns generating and bundling it, so this PR avoids adding a broken README link or claiming it ships.

Closes #266


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated highlights to describe editable in-editor tables with grid controls and keyboard-friendly cell navigation, improving feature discoverability.
  * Added information about raw Markdown editing capabilities as an alternative workflow option via source button and command.
  * Replaced license section with a plain-language summary to improve clarity and accessibility of licensing terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->