### PR TITLE
Give the ProseMirror editor surface an accessible name

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -29,6 +29,8 @@
   "Images must be 10 MB or smaller.": "Images must be 10 MB or smaller.",
   "Image data is empty.": "Image data is empty.",
   "Unsupported image type. Use PNG, JPG, JPEG, GIF, SVG, or WEBP.": "Unsupported image type. Use PNG, JPG, JPEG, GIF, SVG, or WEBP.",
+  "Markdown editor": "Markdown editor",
+  "Markdown editor — {0}": "Markdown editor — {0}",
   "Table {0}: {1} columns, {2} rows": "Table {0}: {1} columns, {2} rows",
   "Mermaid diagram preview": "Mermaid diagram preview",
   "Mermaid diagram": "Mermaid diagram",

--- a/src/custom-editor/muninn-custom-editor-provider.ts
+++ b/src/custom-editor/muninn-custom-editor-provider.ts
@@ -233,6 +233,7 @@ export class MuninnCustomEditorProvider
           type: 'host.init',
           payload: {
             ...this.getHostMarkdownPayload(session),
+            fileName: getDocumentFileName(session.document),
             ...settings,
           },
         });
@@ -603,6 +604,9 @@ export class MuninnCustomEditorProvider
 
 const createNonce = (): string =>
   Array.from({ length: 16 }, () => Math.floor(Math.random() * 16).toString(16)).join('');
+
+const getDocumentFileName = (document: vscode.TextDocument): string =>
+  path.basename(document.uri.fsPath).trim();
 
 const collectMarkdownImageSources = (markdown: string): string[] => {
   const sources = new Set<string>();

--- a/src/custom-editor/protocol.ts
+++ b/src/custom-editor/protocol.ts
@@ -23,6 +23,7 @@ export type HostToViewMessage =
   | {
       type: 'host.init';
       payload: SerializedMarkdownPayload & {
+        fileName: string;
         mermaidEnabled: boolean;
         toolbarMode: ToolbarMode;
         imageSources: ImageUriMap;
@@ -201,6 +202,7 @@ export const isHostToViewMessage = (value: unknown): value is HostToViewMessage 
     return (
       isSerializedMarkdownPayload(payload) &&
       isObject(payload) &&
+      isString((payload as { fileName?: unknown }).fileName) &&
       typeof (payload as { mermaidEnabled?: unknown }).mermaidEnabled === 'boolean' &&
       isToolbarMode((payload as { toolbarMode?: unknown }).toolbarMode) &&
       isImageUriMap((payload as { imageSources?: unknown }).imageSources)

--- a/src/shared/webview-strings.ts
+++ b/src/shared/webview-strings.ts
@@ -28,6 +28,8 @@ export type WebviewStrings = {
   toolbarButtonSourceLabel: string;
   toolbarMoreLabel: string;
   toolbarMoreTitle: string;
+  editorAriaLabel: string;
+  editorAriaLabelTemplate: string;
   mermaidPreviewTitle: string;
   mermaidPreviewAriaLabel: string;
   statusReady: string;
@@ -127,6 +129,8 @@ export const DEFAULT_WEBVIEW_STRINGS: WebviewStrings = {
   toolbarButtonSourceLabel: 'Source',
   toolbarMoreLabel: 'More',
   toolbarMoreTitle: 'Show advanced toolbar actions',
+  editorAriaLabel: 'Markdown editor',
+  editorAriaLabelTemplate: 'Markdown editor — {0}',
   mermaidPreviewTitle: 'Mermaid Preview',
   mermaidPreviewAriaLabel: 'Mermaid diagram preview',
   statusReady: 'Ready',

--- a/src/webview/editor/editor-accessibility.ts
+++ b/src/webview/editor/editor-accessibility.ts
@@ -1,0 +1,15 @@
+import { formatString, getString } from './localization';
+
+export const getEditorAriaLabel = (fileName: string): string => {
+  const trimmedFileName = fileName.trim();
+  if (trimmedFileName.length === 0) {
+    return getString('editorAriaLabel');
+  }
+  return formatString(getString('editorAriaLabelTemplate'), trimmedFileName);
+};
+
+export const getEditorViewAttributes = (fileName: string): Record<string, string> => ({
+  'aria-label': getEditorAriaLabel(fileName),
+  'aria-multiline': 'true',
+  role: 'textbox',
+});

--- a/src/webview/editor/index.ts
+++ b/src/webview/editor/index.ts
@@ -17,6 +17,7 @@ import { formatString, getString } from './localization';
 import { markdownParser, schema, serializeToHostMarkdown } from './markdown-codec';
 import { wrapTablesForEditor } from './markdown-transforms';
 import { attachHostMessageListener } from './messages';
+import { getEditorViewAttributes } from './editor-accessibility';
 import { createFrontMatterNodeViewConstructor } from './nodes/front-matter-node-view';
 import { isMermaidCodeBlockNode } from './nodes/mermaid-node';
 import { createCodeBlockNodeViewConstructor, isTableCodeBlockNode } from './nodes/table-node-view';
@@ -110,6 +111,7 @@ let toolbarMode: ToolbarMode = 'basic';
 let advancedActionsVisible = false;
 let lastMermaidInsertAt = 0;
 let imageSources = new Map<string, string>();
+let documentFileName = '';
 
 const setStatus = (message: string): void => {
   statusLine.textContent = message;
@@ -904,12 +906,15 @@ const updateToolbarState = (): void => {
   );
 };
 
-const applyHostMarkdown = (hostMarkdown: string): void => {
+const applyHostMarkdown = (hostMarkdown: string, fileName = documentFileName): void => {
+  documentFileName = fileName;
+  const editorViewAttributes = getEditorViewAttributes(documentFileName);
   const editorMarkdown = wrapTablesForEditor(hostMarkdown);
 
   if (!view) {
     view = new EditorView(editorContainer, {
       state: parseMarkdown(editorMarkdown),
+      attributes: editorViewAttributes,
       nodeViews: {
         code_block: createCodeBlockNodeViewConstructor({ setStatus }),
         front_matter: createFrontMatterNodeViewConstructor(),
@@ -931,6 +936,7 @@ const applyHostMarkdown = (hostMarkdown: string): void => {
     return;
   }
 
+  view.setProps({ attributes: editorViewAttributes });
   const currentHostMarkdown = serializeMarkdownForHost();
   if (currentHostMarkdown === hostMarkdown) {
     return;
@@ -949,7 +955,7 @@ const detachHostMessageListener = attachHostMessageListener({
     mermaidPreview.setEnabled(payload.mermaidEnabled);
     setImageSources(payload.imageSources);
     setToolbarMode(payload.toolbarMode);
-    applyHostMarkdown(payload.markdown);
+    applyHostMarkdown(payload.markdown, payload.fileName);
     setStatus(getString('statusConnected'));
     view?.focus();
   },

--- a/src/webview/editor/messages.ts
+++ b/src/webview/editor/messages.ts
@@ -8,6 +8,7 @@ import { isHostToViewMessage } from '../../custom-editor/protocol';
 
 type HostMessageHandlers = {
   onInit: (payload: {
+    fileName: string;
     markdown: string;
     revision: number;
     mermaidEnabled: boolean;

--- a/tests/e2e/accessibility-toolbar.e2e.mjs
+++ b/tests/e2e/accessibility-toolbar.e2e.mjs
@@ -7,6 +7,81 @@ import {
 } from './helpers.mjs';
 
 describe('Toolbar accessibility workflow', () => {
+  it('names the editable markdown surface with the document file name', async () => {
+    await openWorkspaceFile('sample.md');
+    await waitForCustomEditor('sample.md');
+
+    await withCustomEditorWebview(async () => {
+      const attributes = await browser.execute(() => {
+        const editor = document.querySelector('.ProseMirror');
+        return {
+          ariaLabel: editor?.getAttribute('aria-label') ?? null,
+          ariaMultiline: editor?.getAttribute('aria-multiline') ?? null,
+          role: editor?.getAttribute('role') ?? null,
+        };
+      });
+
+      expect(attributes).toEqual({
+        ariaLabel: 'Markdown editor — sample.md',
+        ariaMultiline: 'true',
+        role: 'textbox',
+      });
+    });
+  });
+
+  it('keeps the editable markdown surface named after host document replacement', async () => {
+    await openWorkspaceFile('sample.md');
+    await waitForCustomEditor('sample.md');
+
+    await browser.executeWorkbench(async (vscode) => {
+      const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+      if (!workspaceFolder) {
+        throw new Error('No workspace folder available in VS Code test session.');
+      }
+
+      const uri = vscode.Uri.joinPath(workspaceFolder.uri, 'sample.md');
+      const document = await vscode.workspace.openTextDocument(uri);
+      const edit = new vscode.WorkspaceEdit();
+      edit.replace(
+        uri,
+        new vscode.Range(
+          new vscode.Position(0, 0),
+          document.lineAt(document.lineCount - 1).range.end,
+        ),
+        '# Replaced\n\nHost-driven update.\n',
+      );
+      await vscode.workspace.applyEdit(edit);
+    });
+
+    await withCustomEditorWebview(async () => {
+      await browser.waitUntil(
+        async () =>
+          browser.execute(() =>
+            document.querySelector('.ProseMirror')?.textContent?.includes('Replaced'),
+          ),
+        {
+          timeout: 5_000,
+          timeoutMsg: 'Expected host-driven document replacement to reach the webview editor.',
+        },
+      );
+
+      const attributes = await browser.execute(() => {
+        const editor = document.querySelector('.ProseMirror');
+        return {
+          ariaLabel: editor?.getAttribute('aria-label') ?? null,
+          ariaMultiline: editor?.getAttribute('aria-multiline') ?? null,
+          role: editor?.getAttribute('role') ?? null,
+        };
+      });
+
+      expect(attributes).toEqual({
+        ariaLabel: 'Markdown editor — sample.md',
+        ariaMultiline: 'true',
+        role: 'textbox',
+      });
+    });
+  });
+
   it('shows the editor shell focus ring when the document is focused', async () => {
     await openWorkspaceFile('with-formatting.md');
     await waitForCustomEditor('with-formatting.md');

--- a/tests/unit/editor-accessibility.test.ts
+++ b/tests/unit/editor-accessibility.test.ts
@@ -1,0 +1,28 @@
+import {
+  getEditorAriaLabel,
+  getEditorViewAttributes,
+} from '../../src/webview/editor/editor-accessibility';
+
+let expect: Chai.ExpectStatic;
+
+before(async () => {
+  ({ expect } = await import('chai'));
+});
+
+describe('editor accessibility helpers', () => {
+  it('formats the localized editor label with a file name', () => {
+    expect(getEditorAriaLabel('README.md')).to.equal('Markdown editor — README.md');
+  });
+
+  it('falls back to a plain localized editor label without a file name', () => {
+    expect(getEditorAriaLabel('  ')).to.equal('Markdown editor');
+  });
+
+  it('builds the ProseMirror contenteditable attributes', () => {
+    expect(getEditorViewAttributes('README.md')).to.deep.equal({
+      'aria-label': 'Markdown editor — README.md',
+      'aria-multiline': 'true',
+      role: 'textbox',
+    });
+  });
+});

--- a/tests/unit/protocol.test.ts
+++ b/tests/unit/protocol.test.ts
@@ -1,9 +1,113 @@
-import { isHostToViewMessage, isViewToHostMessage } from '../../src/custom-editor/protocol';
+import sinon from 'sinon';
+import * as vscode from 'vscode';
+import { MuninnCustomEditorProvider } from '../../src/custom-editor/muninn-custom-editor-provider';
+import {
+  type HostToViewMessage,
+  isHostToViewMessage,
+  isViewToHostMessage,
+} from '../../src/custom-editor/protocol';
+import type { ConfigService } from '../../src/services/config-service';
+import type { Logger } from '../../src/services/logger';
 
 let expect: Chai.ExpectStatic;
 
 before(async () => {
   ({ expect } = await import('chai'));
+});
+
+const ensureUriJoinPath = (): void => {
+  if (typeof vscode.Uri.joinPath === 'function') {
+    return;
+  }
+
+  Object.defineProperty(vscode.Uri, 'joinPath', {
+    value: (base: vscode.Uri, ...segments: string[]) => {
+      const joinedFsPath = [base.fsPath, ...segments].join('/').replaceAll(/\/+/g, '/');
+      return vscode.Uri.file(joinedFsPath);
+    },
+  });
+};
+
+const createDocument = (filePath: string, text: string): vscode.TextDocument => {
+  const lines = text.split('\n');
+  return {
+    uri: vscode.Uri.file(filePath),
+    fileName: filePath,
+    getText: () => text,
+    lineCount: lines.length,
+    lineAt: (line: number) => ({
+      range: {
+        end: new vscode.Position(line, lines[line]?.length ?? 0),
+      },
+    }),
+  } as unknown as vscode.TextDocument;
+};
+
+const createPanel = (): {
+  dispatchMessage: (message: unknown) => Promise<void>;
+  panel: vscode.WebviewPanel;
+  postedMessages: HostToViewMessage[];
+} => {
+  let messageListener: ((message: unknown) => unknown) | undefined;
+  const postedMessages: HostToViewMessage[] = [];
+  const webview = {
+    options: {},
+    html: '',
+    asWebviewUri: (uri: vscode.Uri) => uri,
+    onDidReceiveMessage: (listener: (message: unknown) => unknown) => {
+      messageListener = listener;
+      return { dispose: () => {} };
+    },
+    postMessage: async (message: HostToViewMessage) => {
+      postedMessages.push(message);
+      return true;
+    },
+  } as unknown as vscode.Webview;
+
+  return {
+    panel: {
+      webview,
+      onDidDispose: () => ({ dispose: () => {} }),
+    } as unknown as vscode.WebviewPanel,
+    postedMessages,
+    dispatchMessage: async (message: unknown) => {
+      await Promise.resolve(messageListener?.(message));
+    },
+  };
+};
+
+const createConfigService = (): ConfigService =>
+  ({
+    getMermaidEnabled: () => true,
+    getMermaidAllowInUntrustedWorkspaces: () => true,
+    getToolbarMode: () => 'basic',
+    getImageDestination: () => 'images/',
+  }) as unknown as ConfigService;
+
+const createLogger = (): Logger =>
+  ({
+    warn: sinon.stub(),
+    error: sinon.stub(),
+  }) as unknown as Logger;
+
+describe('custom editor init protocol', () => {
+  it('includes the document file name in the host init payload', async () => {
+    ensureUriJoinPath();
+    const provider = new MuninnCustomEditorProvider(
+      vscode.Uri.file('/extension'),
+      createConfigService(),
+      createLogger(),
+    );
+    const document = createDocument('/workspace/notes/Welcome.md', '# Welcome\n');
+    const { dispatchMessage, panel, postedMessages } = createPanel();
+
+    await provider.resolveCustomTextEditor(document, panel);
+    await dispatchMessage({ type: 'view.ready' });
+
+    const initMessage = postedMessages.find((message) => message.type === 'host.init');
+
+    expect(initMessage?.payload.fileName).to.equal('Welcome.md');
+  });
 });
 
 describe('custom editor protocol guards', () => {
@@ -63,6 +167,7 @@ describe('custom editor protocol guards', () => {
       isHostToViewMessage({
         type: 'host.init',
         payload: {
+          fileName: 'README.md',
           markdown: '# title',
           revision: 1,
           mermaidEnabled: true,
@@ -119,6 +224,18 @@ describe('custom editor protocol guards', () => {
       isHostToViewMessage({
         type: 'host.init',
         payload: { markdown: '', revision: 0, mermaidEnabled: true },
+      }),
+    ).to.equal(false);
+    expect(
+      isHostToViewMessage({
+        type: 'host.init',
+        payload: {
+          markdown: '',
+          revision: 0,
+          mermaidEnabled: true,
+          toolbarMode: 'basic',
+          imageSources: {},
+        },
       }),
     ).to.equal(false);
     expect(


### PR DESCRIPTION
## Summary
- Add localized Markdown editor aria-label strings and apply them through ProseMirror EditorView attributes with role=\"textbox\" and aria-multiline=\"true\".
- Extend host.init with fileName, validate it in the protocol guard, and send the document basename from the custom editor provider.
- Cover initial init and host-driven replacement behavior with unit and targeted E2E tests.

## Verification
- npm ci
- npm run format:check
- npm run lint
- npm run typecheck
- npm run check:no-telemetry
- npm run coverage
- npm run compile
- npm run bundle
- xvfb-run -a npm run test:e2e -- --spec tests/e2e/accessibility-toolbar.e2e.mjs --mochaOpts.grep \"editable markdown surface\"

Note: a full local run of tests/e2e/accessibility-toolbar.e2e.mjs passed the two new assertions, then hit the existing runner-window-loss/webview lifecycle failure in later unrelated toolbar tests.

Fixes #251

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced editor accessibility with proper ARIA labels that include the document filename, improving screen reader compatibility and keyboard navigation.

* **Tests**
  * Added comprehensive test coverage for editor accessibility features and filename handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->