### PR TITLE
Fix toolbar tier membership

### DIFF
--- a/src/webview/editor/bootstrap.ts
+++ b/src/webview/editor/bootstrap.ts
@@ -36,18 +36,18 @@ export const bootstrapEditorApp = (): EditorBootstrap => {
       <button type="button" data-command="setHeading1" aria-pressed="false" tabindex="-1" title="${getHtmlString('toolbarButtonHeading1Title')}">${getHtmlString('toolbarButtonHeading1Label')}</button>
       <button type="button" data-command="setHeading2" aria-pressed="false" tabindex="-1" title="${getHtmlString('toolbarButtonHeading2Title')}">${getHtmlString('toolbarButtonHeading2Label')}</button>
       <button type="button" id="muninn-toolbar-heading-3" data-command="setHeading3" aria-pressed="false" data-advanced="true" tabindex="-1" hidden title="${getHtmlString('toolbarButtonHeading3Title')}">${getHtmlString('toolbarButtonHeading3Label')}</button>
-      <button type="button" data-command="setParagraph" aria-pressed="false" tabindex="-1" title="${getHtmlString('toolbarButtonParagraphTitle')}">${getHtmlString('commandLabelParagraph')}</button>
-      <button type="button" id="muninn-toolbar-bullet-list" data-command="toggleBulletList" aria-pressed="false" data-advanced="true" tabindex="-1" hidden title="${getHtmlString('toolbarButtonBulletTitle')}">${getHtmlString('toolbarButtonBulletLabel')}</button>
-      <button type="button" id="muninn-toolbar-numbered-list" data-command="toggleNumberedList" aria-pressed="false" data-advanced="true" tabindex="-1" hidden title="${getHtmlString('toolbarButtonNumberedTitle')}">${getHtmlString('toolbarButtonNumberedLabel')}</button>
+      <button type="button" id="muninn-toolbar-paragraph" data-command="setParagraph" aria-pressed="false" data-advanced="true" tabindex="-1" hidden title="${getHtmlString('toolbarButtonParagraphTitle')}">${getHtmlString('commandLabelParagraph')}</button>
+      <button type="button" data-command="toggleBulletList" aria-pressed="false" tabindex="-1" title="${getHtmlString('toolbarButtonBulletTitle')}">${getHtmlString('toolbarButtonBulletLabel')}</button>
+      <button type="button" data-command="toggleNumberedList" aria-pressed="false" tabindex="-1" title="${getHtmlString('toolbarButtonNumberedTitle')}">${getHtmlString('toolbarButtonNumberedLabel')}</button>
     </div>
     <div class="muninn-toolbar-group" data-group="insert" role="group" aria-labelledby="muninn-toolbar-group-insert-label">
       <span id="muninn-toolbar-group-insert-label" class="muninn-toolbar-group-label">${getHtmlString('toolbarGroupInsertLabel')}</span>
       <button type="button" data-command="insertTable" tabindex="-1" title="${getHtmlString('toolbarButtonTableTitle')}">${getHtmlString('commandLabelTable')}</button>
-      <button type="button" data-command="insertCodeBlock" tabindex="-1" title="${getHtmlString('toolbarButtonCodeTitle')}">${getHtmlString('commandLabelCodeBlock')}</button>
+      <button type="button" id="muninn-toolbar-code-block" data-command="insertCodeBlock" data-advanced="true" tabindex="-1" hidden title="${getHtmlString('toolbarButtonCodeTitle')}">${getHtmlString('commandLabelCodeBlock')}</button>
       <button type="button" id="muninn-toolbar-mermaid" data-command="insertMermaidBlock" data-advanced="true" tabindex="-1" hidden title="${getHtmlString('toolbarButtonMermaidTitle')}">${getHtmlString('toolbarButtonMermaidLabel')}</button>
       <button type="button" data-command="openRawMarkdown" tabindex="-1" title="${getHtmlString('toolbarButtonSourceTitle')}">${getHtmlString('toolbarButtonSourceLabel')}</button>
     </div>
-    <button type="button" class="muninn-toolbar-more" data-testid="muninn-toolbar-more" aria-controls="muninn-toolbar-heading-3 muninn-toolbar-bullet-list muninn-toolbar-numbered-list muninn-toolbar-mermaid" aria-expanded="false" tabindex="-1" title="${getHtmlString('toolbarMoreTitle')}">${getHtmlString('toolbarMoreLabel')}</button>
+    <button type="button" class="muninn-toolbar-more" data-testid="muninn-toolbar-more" aria-controls="muninn-toolbar-heading-3 muninn-toolbar-paragraph muninn-toolbar-code-block muninn-toolbar-mermaid" aria-expanded="false" tabindex="-1" title="${getHtmlString('toolbarMoreTitle')}">${getHtmlString('toolbarMoreLabel')}</button>
   </div>
   <div class="muninn-editor-shell" id="editor-shell">
     <section id="mermaid-preview-panel" class="muninn-mermaid-preview-panel" aria-label="${getHtmlString('mermaidPreviewAriaLabel')}" hidden>

--- a/src/webview/editor/index.ts
+++ b/src/webview/editor/index.ts
@@ -39,8 +39,8 @@ const vscode = acquireVsCodeApi();
 
 const ADVANCED_TOOLBAR_COMMANDS = new Set<string>([
   'setHeading3',
-  'toggleBulletList',
-  'toggleNumberedList',
+  'setParagraph',
+  'insertCodeBlock',
   'insertMermaidBlock',
 ]);
 

--- a/tests/e2e/accessibility-toolbar.e2e.mjs
+++ b/tests/e2e/accessibility-toolbar.e2e.mjs
@@ -116,6 +116,14 @@ describe('Toolbar accessibility workflow', () => {
 
       const heading3Button = await browser.$('[data-command="setHeading3"]');
       await expect(heading3Button).not.toBeDisplayed();
+      const paragraphButton = await browser.$('[data-command="setParagraph"]');
+      await expect(paragraphButton).not.toBeDisplayed();
+      const codeButton = await browser.$('[data-command="insertCodeBlock"]');
+      await expect(codeButton).not.toBeDisplayed();
+      const bulletListButton = await browser.$('[data-command="toggleBulletList"]');
+      await expect(bulletListButton).toBeDisplayed();
+      const numberedListButton = await browser.$('[data-command="toggleNumberedList"]');
+      await expect(numberedListButton).toBeDisplayed();
 
       const moreButton = await browser.$('[data-testid="muninn-toolbar-more"]');
       await expect(moreButton).toBeDisplayed();
@@ -142,6 +150,8 @@ describe('Toolbar accessibility workflow', () => {
       await moreButton.click();
 
       await expect(heading3Button).toBeDisplayed();
+      await expect(paragraphButton).toBeDisplayed();
+      await expect(codeButton).toBeDisplayed();
       await expect(moreButton).toHaveAttribute('aria-expanded', 'true');
       await browser.waitUntil(
         async () => {


### PR DESCRIPTION
## Summary
- Move bullet and numbered list buttons into basic toolbar mode.
- Move Paragraph and Code block behind More alongside H3 and Mermaid.
- Update toolbar E2E assertions for the new basic-mode visible buttons and advanced controls.

## Verification
- npm ci
- npm run format:check
- npm run lint
- npm run typecheck
- npm run check:no-telemetry
- npm run coverage
- npm run compile
- npm run bundle
- xvfb-run -a npm run test:e2e -- --spec tests/e2e/accessibility-toolbar.e2e.mjs --mochaOpts.grep "labels toolbar groups|uses one toolbar tab stop"

Fixes #254

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Editor Toolbar

* **Updates**
  * Toolbar buttons have been reorganized for improved formatting access
  * Bullet list and numbered list buttons are now visible by default in the main toolbar
  * Paragraph and code block formatting options have been moved to the advanced menu

<!-- end of auto-generated comment: release notes by coderabbit.ai -->