### PR TITLE
feat(editor): constrain document content width

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Muninn provides a reading-first Markdown experience in VS Code with a custom edi
 - `muninn.integrations.mermaid.enabled`
 - `muninn.integrations.mermaid.allowInUntrustedWorkspaces`
 - `muninn.toolbar.mode` (`basic` or `advanced`)
+- `muninn.appearance.contentWidth` (`comfortable` by default, `full`, or a number from 40 to 120)
 - `muninn.images.destination` (`images/` by default, relative to the current Markdown document)
 
 ## Security

--- a/package.json
+++ b/package.json
@@ -422,6 +422,25 @@
           "description": "%configuration.toolbar.mode.description%",
           "scope": "window"
         },
+        "muninn.appearance.contentWidth": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "comfortable",
+                "full"
+              ]
+            },
+            {
+              "type": "number",
+              "minimum": 40,
+              "maximum": 120
+            }
+          ],
+          "default": "comfortable",
+          "description": "%configuration.appearance.contentWidth.description%",
+          "scope": "window"
+        },
         "muninn.images.destination": {
           "type": "string",
           "default": "images/",

--- a/package.nls.json
+++ b/package.nls.json
@@ -43,5 +43,6 @@
   "configuration.integrations.mermaid.enabled.description": "Enable inline Mermaid rendering inside the Muninn custom markdown editor.",
   "configuration.integrations.mermaid.allowInUntrustedWorkspaces.description": "Allow Mermaid rendering in restricted workspaces (disabled by default for safety).",
   "configuration.toolbar.mode.description": "Choose the Muninn toolbar mode. Basic shows core actions, advanced shows the full authoring toolbar.",
+  "configuration.appearance.contentWidth.description": "Controls the document content column width. Comfortable uses 70ch, full uses the editor width, and numbers from 40 to 120 are treated as ch units.",
   "configuration.images.destination.description": "Folder for pasted, dropped, and picked image files, relative to the current Markdown document."
 }

--- a/src/custom-editor/muninn-custom-editor-provider.ts
+++ b/src/custom-editor/muninn-custom-editor-provider.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import MarkdownIt from 'markdown-it';
 import { ConfigService } from '../services/config-service';
 import { Logger } from '../services/logger';
+import type { ContentWidthSetting } from '../types/config';
 import { isMermaidIntegrationActive } from '../integrations/mermaid-adapter';
 import { t } from '../utils/l10n';
 import { DEFAULT_WEBVIEW_STRINGS, type WebviewStrings } from '../shared/webview-strings';
@@ -60,6 +61,7 @@ type EditorSession = {
 type SessionSettings = {
   mermaidEnabled: boolean;
   toolbarMode: ToolbarMode;
+  contentWidth: ContentWidthSetting;
 };
 
 type HostMarkdownPayload = SerializedMarkdownPayload & {
@@ -321,6 +323,7 @@ export class MuninnCustomEditorProvider
     return {
       mermaidEnabled: isMermaidIntegrationActive(this.configService, resource),
       toolbarMode: this.configService.getToolbarMode(resource),
+      contentWidth: this.configService.getContentWidth(resource),
     };
   }
 

--- a/src/custom-editor/protocol.ts
+++ b/src/custom-editor/protocol.ts
@@ -1,3 +1,5 @@
+import type { ContentWidthSetting } from '../types/config';
+
 export type DocumentRevision = number;
 export type ToolbarMode = 'basic' | 'advanced';
 export type ImageInsertKind = 'paste' | 'drop';
@@ -26,6 +28,7 @@ export type HostToViewMessage =
         fileName: string;
         mermaidEnabled: boolean;
         toolbarMode: ToolbarMode;
+        contentWidth: ContentWidthSetting;
         imageSources: ImageUriMap;
       };
     }
@@ -46,6 +49,7 @@ export type HostToViewMessage =
       payload: {
         mermaidEnabled: boolean;
         toolbarMode: ToolbarMode;
+        contentWidth: ContentWidthSetting;
       };
     }
   | {
@@ -155,6 +159,11 @@ const isViewEditorCommand = (value: unknown): value is ViewEditorCommand =>
 const isToolbarMode = (value: unknown): value is ToolbarMode =>
   value === 'basic' || value === 'advanced';
 
+const isContentWidthSetting = (value: unknown): value is ContentWidthSetting =>
+  value === 'comfortable' ||
+  value === 'full' ||
+  (typeof value === 'number' && Number.isFinite(value) && value >= 40 && value <= 120);
+
 export const isViewToHostMessage = (value: unknown): value is ViewToHostMessage => {
   if (!isObject(value) || !isString(value.type)) {
     return false;
@@ -205,6 +214,7 @@ export const isHostToViewMessage = (value: unknown): value is HostToViewMessage 
       isString((payload as { fileName?: unknown }).fileName) &&
       typeof (payload as { mermaidEnabled?: unknown }).mermaidEnabled === 'boolean' &&
       isToolbarMode((payload as { toolbarMode?: unknown }).toolbarMode) &&
+      isContentWidthSetting((payload as { contentWidth?: unknown }).contentWidth) &&
       isImageUriMap((payload as { imageSources?: unknown }).imageSources)
     );
   }
@@ -226,7 +236,8 @@ export const isHostToViewMessage = (value: unknown): value is HostToViewMessage 
     return (
       isObject(value.payload) &&
       typeof value.payload.mermaidEnabled === 'boolean' &&
-      isToolbarMode(value.payload.toolbarMode)
+      isToolbarMode(value.payload.toolbarMode) &&
+      isContentWidthSetting(value.payload.contentWidth)
     );
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -293,6 +293,9 @@ export function activate(context: vscode.ExtensionContext): void {
     );
     outputChannel.appendLine(t('toolbar.mode: {0}', formatInspectValue(inspection.toolbarMode)));
     outputChannel.appendLine(
+      t('appearance.contentWidth: {0}', formatInspectValue(inspection.contentWidth)),
+    );
+    outputChannel.appendLine(
       t('images.destination: {0}', formatInspectValue(inspection.imageDestination)),
     );
     outputChannel.show(true);

--- a/src/services/config-service.ts
+++ b/src/services/config-service.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { ExtensionConfiguration } from '../types/config';
+import { ContentWidthSetting, ExtensionConfiguration } from '../types/config';
 
 export type ConfigInspection<T> = {
   defaultValue?: T;
@@ -13,8 +13,17 @@ const DEFAULT_CONFIG: ExtensionConfiguration = {
   mermaidEnabled: true,
   mermaidAllowInUntrustedWorkspaces: false,
   toolbarMode: 'basic',
+  contentWidth: 'comfortable',
   imageDestination: 'images/',
 };
+
+const isContentWidthSetting = (value: unknown): value is ContentWidthSetting =>
+  value === 'comfortable' ||
+  value === 'full' ||
+  (typeof value === 'number' && Number.isFinite(value) && value >= 40 && value <= 120);
+
+const normalizeContentWidthSetting = (value: unknown): ContentWidthSetting =>
+  isContentWidthSetting(value) ? value : DEFAULT_CONFIG.contentWidth;
 
 export class ConfigService {
   private readonly cachedConfigs = new Map<string, ExtensionConfiguration>();
@@ -33,6 +42,10 @@ export class ConfigService {
 
   getToolbarMode(resource?: vscode.Uri): 'basic' | 'advanced' {
     return this.getConfig(resource).toolbarMode;
+  }
+
+  getContentWidth(resource?: vscode.Uri): ContentWidthSetting {
+    return this.getConfig(resource).contentWidth;
   }
 
   getImageDestination(resource?: vscode.Uri): string {
@@ -66,6 +79,7 @@ export class ConfigService {
     mermaidEnabled?: ConfigInspection<boolean>;
     mermaidAllowInUntrustedWorkspaces?: ConfigInspection<boolean>;
     toolbarMode?: ConfigInspection<'basic' | 'advanced'>;
+    contentWidth?: ConfigInspection<ContentWidthSetting>;
     imageDestination?: ConfigInspection<string>;
   } {
     const config = vscode.workspace.getConfiguration('muninn', resource);
@@ -76,6 +90,7 @@ export class ConfigService {
         'integrations.mermaid.allowInUntrustedWorkspaces',
       ),
       toolbarMode: config.inspect<'basic' | 'advanced'>('toolbar.mode'),
+      contentWidth: config.inspect<ContentWidthSetting>('appearance.contentWidth'),
       imageDestination: config.inspect<string>('images.destination'),
     };
   }
@@ -94,6 +109,9 @@ export class ConfigService {
         DEFAULT_CONFIG.mermaidAllowInUntrustedWorkspaces,
       ),
       toolbarMode: config.get('toolbar.mode', DEFAULT_CONFIG.toolbarMode),
+      contentWidth: normalizeContentWidthSetting(
+        config.get<unknown>('appearance.contentWidth', DEFAULT_CONFIG.contentWidth),
+      ),
       imageDestination: config.get('images.destination', DEFAULT_CONFIG.imageDestination),
     };
   }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,7 +1,10 @@
+export type ContentWidthSetting = 'comfortable' | 'full' | number;
+
 export interface ExtensionConfiguration {
   editorAssociations: boolean;
   mermaidEnabled: boolean;
   mermaidAllowInUntrustedWorkspaces: boolean;
   toolbarMode: 'basic' | 'advanced';
+  contentWidth: ContentWidthSetting;
   imageDestination: string;
 }

--- a/src/webview/editor/bootstrap.ts
+++ b/src/webview/editor/bootstrap.ts
@@ -3,6 +3,7 @@ import { getHtmlString } from './localization';
 export type EditorBootstrap = {
   app: HTMLDivElement;
   toolbar: HTMLDivElement;
+  editorShell: HTMLDivElement;
   editorContainer: HTMLDivElement;
   statusLine: HTMLDivElement;
   alertLine: HTMLDivElement;
@@ -64,6 +65,7 @@ export const bootstrapEditorApp = (): EditorBootstrap => {
 `;
 
   const toolbar = document.querySelector<HTMLDivElement>('.muninn-toolbar');
+  const editorShell = document.querySelector<HTMLDivElement>('#editor-shell');
   const editorContainer = document.querySelector<HTMLDivElement>('#editor');
   const statusLine = document.querySelector<HTMLDivElement>('#status');
   const alertLine = document.querySelector<HTMLDivElement>('#status-alert');
@@ -71,6 +73,7 @@ export const bootstrapEditorApp = (): EditorBootstrap => {
   const mermaidPreviewBody = document.querySelector<HTMLDivElement>('#mermaid-preview-body');
   if (
     !toolbar ||
+    !editorShell ||
     !editorContainer ||
     !statusLine ||
     !alertLine ||
@@ -92,6 +95,7 @@ export const bootstrapEditorApp = (): EditorBootstrap => {
   return {
     app,
     toolbar,
+    editorShell,
     editorContainer,
     statusLine,
     alertLine,

--- a/src/webview/editor/content-width.ts
+++ b/src/webview/editor/content-width.ts
@@ -1,0 +1,22 @@
+import type { ContentWidthSetting } from '../../types/config';
+
+const CONTENT_WIDTH_PROPERTY = '--muninn-content-width';
+
+export const resolveContentWidthCssValue = (contentWidth: ContentWidthSetting): string => {
+  if (contentWidth === 'comfortable') {
+    return '70ch';
+  }
+
+  if (contentWidth === 'full') {
+    return 'none';
+  }
+
+  return `${contentWidth}ch`;
+};
+
+export const applyContentWidth = (
+  editorShell: Pick<HTMLElement, 'style'>,
+  contentWidth: ContentWidthSetting,
+): void => {
+  editorShell.style.setProperty(CONTENT_WIDTH_PROPERTY, resolveContentWidthCssValue(contentWidth));
+};

--- a/src/webview/editor/index.ts
+++ b/src/webview/editor/index.ts
@@ -13,6 +13,7 @@ import type {
 } from '../../custom-editor/protocol';
 import { createAnnouncer } from './announcements';
 import { bootstrapEditorApp } from './bootstrap';
+import { applyContentWidth } from './content-width';
 import { createImageInsertionTransaction } from './image-insertion';
 import { formatString, getString } from './localization';
 import { markdownParser, schema, serializeToHostMarkdown } from './markdown-codec';
@@ -98,6 +99,7 @@ const formatCommandFailure = (command: string): string => {
 
 const {
   editorContainer,
+  editorShell,
   toolbar,
   statusLine,
   alertLine,
@@ -953,6 +955,7 @@ const detachHostMessageListener = attachHostMessageListener({
   onInit: (payload) => {
     syncController.setRevision(payload.revision);
     mermaidPreview.setEnabled(payload.mermaidEnabled);
+    applyContentWidth(editorShell, payload.contentWidth);
     setImageSources(payload.imageSources);
     setToolbarMode(payload.toolbarMode);
     applyHostMarkdown(payload.markdown, payload.fileName);
@@ -975,6 +978,7 @@ const detachHostMessageListener = attachHostMessageListener({
   },
   onSettingsChanged: (payload) => {
     mermaidPreview.setEnabled(payload.mermaidEnabled);
+    applyContentWidth(editorShell, payload.contentWidth);
     setToolbarMode(payload.toolbarMode);
     schedulePreviewRender();
   },

--- a/src/webview/editor/messages.ts
+++ b/src/webview/editor/messages.ts
@@ -4,6 +4,7 @@ import type {
   ToolbarMode,
   ViewEditorCommand,
 } from '../../custom-editor/protocol';
+import type { ContentWidthSetting } from '../../types/config';
 import { isHostToViewMessage } from '../../custom-editor/protocol';
 
 type HostMessageHandlers = {
@@ -13,6 +14,7 @@ type HostMessageHandlers = {
     revision: number;
     mermaidEnabled: boolean;
     toolbarMode: ToolbarMode;
+    contentWidth: ContentWidthSetting;
     imageSources: ImageUriMap;
   }) => void;
   onDocumentChanged: (payload: {
@@ -21,7 +23,11 @@ type HostMessageHandlers = {
     imageSources: ImageUriMap;
   }) => void;
   onExecuteCommand: (command: ViewEditorCommand) => void;
-  onSettingsChanged: (payload: { mermaidEnabled: boolean; toolbarMode: ToolbarMode }) => void;
+  onSettingsChanged: (payload: {
+    mermaidEnabled: boolean;
+    toolbarMode: ToolbarMode;
+    contentWidth: ContentWidthSetting;
+  }) => void;
   onInsertLink: (payload: { href: string; text?: string }) => void;
   onImageInserted: (payload: { path: string; webviewUri: string; filename: string }) => void;
   onImageRejected: (payload: { reason: string }) => void;

--- a/src/webview/editor/styles.css
+++ b/src/webview/editor/styles.css
@@ -144,6 +144,9 @@ body {
 }
 
 .muninn-editor-shell {
+  --muninn-content-gutter: 22px;
+  --muninn-content-width: 70ch;
+
   flex: 1;
   overflow: auto;
   outline: 2px solid transparent;
@@ -156,8 +159,12 @@ body {
 }
 
 .ProseMirror {
+  box-sizing: border-box;
+  width: calc(100% - (var(--muninn-content-gutter) * 2));
+  max-width: var(--muninn-content-width);
   min-height: 100%;
-  padding: 18px 22px 40px;
+  margin: 0 auto;
+  padding: 18px 0 40px;
   outline: none;
   line-height: 1.6;
 }
@@ -187,9 +194,12 @@ body {
 }
 
 .muninn-mermaid-preview-panel {
+  box-sizing: border-box;
+  width: calc(100% - (var(--muninn-content-gutter) * 2));
+  max-width: var(--muninn-content-width);
   border: 1px solid var(--vscode-editorWidget-border);
   border-radius: 8px;
-  margin: 10px 12px;
+  margin: 10px auto;
   background: color-mix(in srgb, var(--vscode-editorWidget-background) 86%, transparent);
   overflow: hidden;
 }

--- a/tests/e2e/reading-first.e2e.mjs
+++ b/tests/e2e/reading-first.e2e.mjs
@@ -6,6 +6,44 @@ import {
   withCustomEditorWebview,
 } from './helpers.mjs';
 
+const readContentWidthState = async () =>
+  browser.execute(() => {
+    const shell = document.querySelector('#editor-shell');
+    const editor = document.querySelector('.ProseMirror');
+    const panel = document.querySelector('.muninn-mermaid-preview-panel');
+    if (!(shell instanceof HTMLElement) || !(editor instanceof HTMLElement)) {
+      throw new Error('Muninn content-width elements are missing.');
+    }
+
+    const editorRect = editor.getBoundingClientRect();
+    const shellRect = shell.getBoundingClientRect();
+    return {
+      contentWidth: getComputedStyle(shell).getPropertyValue('--muninn-content-width').trim(),
+      editorLeft: editorRect.left,
+      editorRight: shellRect.right - editorRect.right,
+      editorMaxWidth: getComputedStyle(editor).maxWidth,
+      panelMaxWidth: panel instanceof HTMLElement ? getComputedStyle(panel).maxWidth : '',
+      proofMarker: window.__muninnContentWidthProof,
+    };
+  });
+
+const dispatchHostSettingsChanged = async (contentWidth) => {
+  await browser.execute((nextContentWidth) => {
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: {
+          type: 'host.settingsChanged',
+          payload: {
+            mermaidEnabled: true,
+            toolbarMode: 'basic',
+            contentWidth: nextContentWidth,
+          },
+        },
+      }),
+    );
+  }, contentWidth);
+};
+
 describe('Reading-first workflow', () => {
   it('opens markdown files in Muninn custom editor by default', async () => {
     await openWorkspaceFile('sample.md');
@@ -23,6 +61,51 @@ describe('Reading-first workflow', () => {
       const sourceButton = await browser.$('[data-command="openRawMarkdown"]');
       await expect(sourceButton).toHaveText('Source');
       await expect(sourceButton).toHaveAttribute('title', expect.stringContaining('raw Markdown'));
+    });
+  });
+
+  it('updates the document content width live without reopening the webview', async () => {
+    await openWorkspaceFile('sample.md');
+    await waitForCustomEditor('sample.md');
+
+    await withCustomEditorWebview(async () => {
+      await browser.execute(() => {
+        window.__muninnContentWidthProof = 'same-webview-instance';
+      });
+
+      await browser.waitUntil(async () => (await readContentWidthState()).contentWidth === '70ch', {
+        timeout: 5_000,
+        timeoutMsg: 'Expected comfortable content width to apply.',
+      });
+
+      const comfortable = await readContentWidthState();
+      expect(Math.abs(comfortable.editorLeft - comfortable.editorRight)).toBeLessThan(2);
+      expect(comfortable.editorMaxWidth).not.toBe('none');
+      expect(comfortable.panelMaxWidth).not.toBe('none');
+
+      await dispatchHostSettingsChanged('full');
+      await browser.waitUntil(
+        async () => {
+          const state = await readContentWidthState();
+          return state.contentWidth === 'none' && state.proofMarker === 'same-webview-instance';
+        },
+        {
+          timeout: 5_000,
+          timeoutMsg: 'Expected full content width to apply without reopening.',
+        },
+      );
+
+      await dispatchHostSettingsChanged(88);
+      await browser.waitUntil(
+        async () => {
+          const state = await readContentWidthState();
+          return state.contentWidth === '88ch' && state.proofMarker === 'same-webview-instance';
+        },
+        {
+          timeout: 5_000,
+          timeoutMsg: 'Expected numeric content width to apply without reopening.',
+        },
+      );
     });
   });
 });

--- a/tests/unit/config-service.test.ts
+++ b/tests/unit/config-service.test.ts
@@ -13,6 +13,7 @@ type ConfigurationOverrides = {
   mermaidAllowInUntrustedWorkspaces?: boolean;
   toolbarMode?: 'basic' | 'advanced';
   imageDestination?: string;
+  contentWidth?: 'comfortable' | 'full' | number;
 };
 
 const createConfiguration = (overrides?: ConfigurationOverrides): vscode.WorkspaceConfiguration => {
@@ -22,6 +23,7 @@ const createConfiguration = (overrides?: ConfigurationOverrides): vscode.Workspa
     'integrations.mermaid.allowInUntrustedWorkspaces': overrides?.mermaidAllowInUntrustedWorkspaces,
     'toolbar.mode': overrides?.toolbarMode,
     'images.destination': overrides?.imageDestination,
+    'appearance.contentWidth': overrides?.contentWidth,
   };
 
   return {
@@ -54,6 +56,7 @@ describe('ConfigService', () => {
     expect(config.mermaidAllowInUntrustedWorkspaces).to.equal(false);
     expect(config.toolbarMode).to.equal('basic');
     expect(config.imageDestination).to.equal('images/');
+    expect(config.contentWidth).to.equal('comfortable');
   });
 
   it('caches configuration per resource and reloads on demand', () => {
@@ -83,6 +86,7 @@ describe('ConfigService', () => {
         mermaidAllowInUntrustedWorkspaces: true,
         toolbarMode: 'advanced',
         imageDestination: 'assets/',
+        contentWidth: 84,
       }),
     );
 
@@ -94,6 +98,7 @@ describe('ConfigService', () => {
     expect(inspection.mermaidAllowInUntrustedWorkspaces?.globalValue).to.equal(true);
     expect(inspection.toolbarMode?.globalValue).to.equal('advanced');
     expect(inspection.imageDestination?.globalValue).to.equal('assets/');
+    expect(inspection.contentWidth?.globalValue).to.equal(84);
   });
 
   it('exposes convenience getters for active settings', () => {
@@ -104,6 +109,7 @@ describe('ConfigService', () => {
         mermaidAllowInUntrustedWorkspaces: true,
         toolbarMode: 'advanced',
         imageDestination: 'assets/',
+        contentWidth: 'full',
       }),
     );
 
@@ -115,6 +121,7 @@ describe('ConfigService', () => {
     expect(service.getMermaidAllowInUntrustedWorkspaces(uri)).to.equal(true);
     expect(service.getToolbarMode(uri)).to.equal('advanced');
     expect(service.getImageDestination(uri)).to.equal('assets/');
+    expect(service.getContentWidth(uri)).to.equal('full');
   });
 
   it('clears cache and reloads configuration values', () => {

--- a/tests/unit/content-width.test.ts
+++ b/tests/unit/content-width.test.ts
@@ -1,0 +1,34 @@
+import {
+  applyContentWidth,
+  resolveContentWidthCssValue,
+} from '../../src/webview/editor/content-width';
+
+let expect: Chai.ExpectStatic;
+
+before(async () => {
+  ({ expect } = await import('chai'));
+});
+
+class FakeStyle {
+  public readonly properties = new Map<string, string>();
+
+  public setProperty(name: string, value: string): void {
+    this.properties.set(name, value);
+  }
+}
+
+describe('content width helpers', () => {
+  it('maps comfortable, full, and numeric settings to CSS max-width values', () => {
+    expect(resolveContentWidthCssValue('comfortable')).to.equal('70ch');
+    expect(resolveContentWidthCssValue('full')).to.equal('none');
+    expect(resolveContentWidthCssValue(88)).to.equal('88ch');
+  });
+
+  it('applies the content width as a CSS custom property', () => {
+    const element = { style: new FakeStyle() };
+
+    applyContentWidth(element as unknown as HTMLElement, 64);
+
+    expect(element.style.properties.get('--muninn-content-width')).to.equal('64ch');
+  });
+});

--- a/tests/unit/extension.test.ts
+++ b/tests/unit/extension.test.ts
@@ -105,6 +105,7 @@ describe('extension activation', () => {
       mermaidEnabled: true,
       mermaidAllowInUntrustedWorkspaces: false,
       toolbarMode: 'basic',
+      contentWidth: 'comfortable',
       imageDestination: 'images/',
     });
 

--- a/tests/unit/protocol.test.ts
+++ b/tests/unit/protocol.test.ts
@@ -81,6 +81,7 @@ const createConfigService = (): ConfigService =>
     getMermaidEnabled: () => true,
     getMermaidAllowInUntrustedWorkspaces: () => true,
     getToolbarMode: () => 'basic',
+    getContentWidth: () => 'comfortable',
     getImageDestination: () => 'images/',
   }) as unknown as ConfigService;
 
@@ -107,6 +108,7 @@ describe('custom editor init protocol', () => {
     const initMessage = postedMessages.find((message) => message.type === 'host.init');
 
     expect(initMessage?.payload.fileName).to.equal('Welcome.md');
+    expect(initMessage?.payload.contentWidth).to.equal('comfortable');
   });
 });
 
@@ -172,6 +174,7 @@ describe('custom editor protocol guards', () => {
           revision: 1,
           mermaidEnabled: true,
           toolbarMode: 'basic',
+          contentWidth: 'comfortable',
           imageSources: {},
         },
       }),
@@ -185,7 +188,7 @@ describe('custom editor protocol guards', () => {
     expect(
       isHostToViewMessage({
         type: 'host.settingsChanged',
-        payload: { mermaidEnabled: true, toolbarMode: 'advanced' },
+        payload: { mermaidEnabled: true, toolbarMode: 'advanced', contentWidth: 92 },
       }),
     ).to.equal(true);
     expect(
@@ -234,8 +237,28 @@ describe('custom editor protocol guards', () => {
           revision: 0,
           mermaidEnabled: true,
           toolbarMode: 'basic',
+          contentWidth: 'comfortable',
           imageSources: {},
         },
+      }),
+    ).to.equal(false);
+    expect(
+      isHostToViewMessage({
+        type: 'host.init',
+        payload: {
+          fileName: 'README.md',
+          markdown: '',
+          revision: 0,
+          mermaidEnabled: true,
+          toolbarMode: 'basic',
+          imageSources: {},
+        },
+      }),
+    ).to.equal(false);
+    expect(
+      isHostToViewMessage({
+        type: 'host.settingsChanged',
+        payload: { mermaidEnabled: true, toolbarMode: 'basic', contentWidth: 200 },
       }),
     ).to.equal(false);
     expect(


### PR DESCRIPTION
## Summary
- Add `muninn.appearance.contentWidth` (`comfortable`, `full`, or 40-120 number) and flow it through config inspection, provider settings, and the host-to-webview protocol.
- Apply the content width as `--muninn-content-width` on the editor shell so ProseMirror content, table/code cards, and Mermaid previews share the same centered reading measure while toolbar/status remain full-width.
- Document the setting and cover config/protocol/CSS helper behavior plus live webview DOM updates.

## Verification
- `npm ci`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run check:no-telemetry`
- `npm run coverage` (132 passing)
- `npm run compile`
- `npm run bundle`
- `node --check tests/e2e/reading-first.e2e.mjs`
- `xvfb-run -a npm run test:e2e -- --spec tests/e2e/reading-first.e2e.mjs` (2 passing)

Fixes #253
